### PR TITLE
Customisable naming

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,6 +53,7 @@ jobs:
         path: ${{ env.VsixPath }}
         
   release-extension:
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
     needs: build
     runs-on: windows-latest
     steps:
@@ -71,7 +72,6 @@ jobs:
         name: Unitverse-VSIX-VS2022
         path: dist/
     - name: Create Github Release
-      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
       id: create_release
       uses: actions/create-release@v1
       env:

--- a/README.md
+++ b/README.md
@@ -97,8 +97,19 @@ There are replacable tokens which can be substituted into the method names as fo
 | interfaceName | The name of the interface for which generation is currently being performed | When generating tests for an interface implementation |
 | memberName | The unambiguous name of the member being tested (see below) | Everywhere except constructors |
 | memberBareName | The amiguous name of the member being tested (see below) | Everywhere except constructors |
-| parameterName | The name of the parameter being tested for guard conditions | Method guard condition generation |
+| parameterName | The name of the parameter being tested for guard conditions | Method guard condition generation & dependency field name generation |
 | typeParameters | The list of type parameters for an interface | When generating tests for an interface implementation |
+
+#### Formatting options
+
+There are also formatting options for token replacement. This can be achieved with the `{token:format}` syntax - so for instance `{typeName:lower}` will produce the name of the type in lower case. The formatters available are as follows:
+
+| Suffix | Meaning |
+| - | - |
+| lower | The token value is emitted in lower case |
+| upper | The token value is emitted in upper case |
+| camel | The token value is emitted in camel case (i.e. the first letter is converted to lower case) |
+| pascal | The token value is emitted in pascal case (i.e. the first letter is converted to upper case) |
 
 #### On unambiguous vs. ambiguous names
 

--- a/src/Unitverse.Core.Tests/DefaultNamingOptions.cs
+++ b/src/Unitverse.Core.Tests/DefaultNamingOptions.cs
@@ -33,5 +33,9 @@
         public string CanCallOperatorNamingPattern { get; set; } = "CanCall{memberName}Operator";
 
         public string CannotCallOperatorWithNullNamingPattern { get; set; } = "CannotCall{memberName}OperatorWithNull{parameterName}";
+
+        public string TargetFieldName { get; set; } = "_testClass";
+
+        public string DependencyFieldName { get; set; } = "_{parameterName:camel}";
     }
 }

--- a/src/Unitverse.Core.Tests/Helpers/GenerateTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/GenerateTests.cs
@@ -259,6 +259,8 @@ namespace Unitverse.Core.Tests.Helpers
             var model = extractor.Extract(null).First();
             var targetTypeName = "TestValue1540739065";
             var options = Substitute.For<IUnitTestGeneratorOptions>();
+            options.NamingOptions.TargetFieldName.Returns("_testClass");
+            options.NamingOptions.DependencyFieldName.Returns("_{parameterName:camel}");
             options.GenerationOptions.TestTypeNaming.Returns("{0}Tests");
             options.GenerationOptions.FrameworkType.Returns(TestFrameworkTypes.NUnit3);
             var frameworkSet = FrameworkSetFactory.Create(options);

--- a/src/Unitverse.Core.Tests/Models/ClassModelTests.cs
+++ b/src/Unitverse.Core.Tests/Models/ClassModelTests.cs
@@ -10,6 +10,7 @@ namespace Unitverse.Core.Tests.Models
     using Unitverse.Core.Assets;
     using Unitverse.Core.Frameworks;
     using Unitverse.Core.Models;
+    using Unitverse.Core.Options;
 
     [TestFixture]
     public class ClassModelTests
@@ -51,14 +52,21 @@ namespace Unitverse.Core.Tests.Models
         public void CanCallGetConstructorParameterFieldName()
         {
             var parameter = new ParameterModel("param", TestSemanticModelFactory.Parameter, "int", default(TypeInfo));
-            var result = _testClass.GetConstructorParameterFieldName(parameter);
+            var result = _testClass.GetConstructorParameterFieldName(parameter, new NamingProvider(new DefaultNamingOptions()));
             Assert.That(result, Is.EqualTo("_param"));
         }
 
         [Test]
         public void CannotCallGetConstructorParameterFieldNameWithNullParameter()
         {
-            Assert.Throws<ArgumentNullException>(() => _testClass.GetConstructorParameterFieldName(default(ParameterModel)));
+            Assert.Throws<ArgumentNullException>(() => _testClass.GetConstructorParameterFieldName(default(ParameterModel), new NamingProvider(new DefaultNamingOptions())));
+        }
+
+        [Test]
+        public void CannotCallGetConstructorParameterFieldNameWithNullNamingProvider()
+        {
+            var parameter = new ParameterModel("param", TestSemanticModelFactory.Parameter, "int", default(TypeInfo));
+            Assert.Throws<ArgumentNullException>(() => _testClass.GetConstructorParameterFieldName(parameter, null));
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Options/NameResolverTests.cs
+++ b/src/Unitverse.Core.Tests/Options/NameResolverTests.cs
@@ -1,0 +1,68 @@
+namespace Unitverse.Core.Tests.Options
+{
+    using Unitverse.Core.Options;
+    using System;
+    using FluentAssertions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class NameResolverTests
+    {
+        private string _pattern;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _pattern = "TestValue222916131";
+            
+        }
+
+        [Test]
+        public void CanConstruct()
+        {
+            var instance = new NameResolver(_pattern);
+            instance.Should().NotBeNull();
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void CanConstructWithInvalidPattern(string value)
+        {
+            FluentActions.Invoking(() => new NameResolver(value)).Should().NotThrow();
+        }
+
+        [Test]
+        [TestCase("someStuff{typeName}", "someStuffType1")]
+        [TestCase("someStuff{typeName}{interfaceName}", "someStuffType1Interface1")]
+        [TestCase("someStuff{typeName:camel}{interfaceName}", "someStufftype1Interface1")]
+        [TestCase("{interfaceName}", "Interface1")]
+        [TestCase("{memberName}", "Member1WithThing")]
+        [TestCase("{memberName:upper}", "MEMBER1WITHTHING")]
+        [TestCase("{memberName:lower}", "member1withthing")]
+        [TestCase("{memberName:nonexitstent}", "Member1WithThing")]
+        [TestCase("{nonexitstent}", "")]
+        [TestCase("{nonexitstent:nonexitstent}", "")]
+        [TestCase("{badlyFormatted", "")]
+        [TestCase("badlyFormatted}", "badlyFormatted}")]
+        [TestCase("{memberBareName}", "Member1")]
+        [TestCase("{parameterName}", "parameter1")]
+        [TestCase("_{parameterName:camel}", "_parameter1")]
+        [TestCase("{parameterName:pascal}", "Parameter1")]
+        [TestCase("{typeParameters}", "TypeParam1")]
+        public void CanCallResolve(string pattern, string expectedResult)
+        {
+            var context = new NamingContext("Type1").WithInterfaceName("Interface1").WithMemberName("Member1WithThing", "Member1").WithParameterName("parameter1").WithTypeParameters("TypeParam1");
+            var testClass = new NameResolver(pattern);
+            var result = testClass.Resolve(context);
+            result.Should().Be(expectedResult);
+        }
+
+        [Test]
+        public void CannotCallResolveWithNullContext()
+        {
+            FluentActions.Invoking(() => new NameResolver(_pattern).Resolve(default(NamingContext))).Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/src/Unitverse.Core/CoreGenerator.cs
+++ b/src/Unitverse.Core/CoreGenerator.cs
@@ -274,7 +274,7 @@
                 var fields = new List<FieldDeclarationSyntax>();
                 foreach (var parameterModel in classModel.Constructors.SelectMany(x => x.Parameters))
                 {
-                    allFields.Add(classModel.GetConstructorParameterFieldName(parameterModel));
+                    allFields.Add(classModel.GetConstructorParameterFieldName(parameterModel, frameworkSet.NamingProvider));
                 }
 
                 // generate fields for each constructor parameter that doesn't have an existing field
@@ -285,7 +285,7 @@
                         continue;
                     }
 
-                    var fieldName = classModel.GetConstructorParameterFieldName(parameterModel);
+                    var fieldName = classModel.GetConstructorParameterFieldName(parameterModel, frameworkSet.NamingProvider);
 
                     var fieldExists = targetType.Members.OfType<FieldDeclarationSyntax>().Any(x => x.Declaration.Variables.Any(v => v.Identifier.Text == fieldName));
 
@@ -356,6 +356,7 @@
 
             foreach (var c in classModels)
             {
+                c.SetTargetInstance(frameworkSet.NamingProvider.TargetFieldName.Resolve(new NamingContext(c.ClassName)));
                 if (c.Declaration.Parent is NamespaceDeclarationSyntax namespaceDeclaration)
                 {
                     targetNamespace = EmitUsingStatements(targetNamespace, usingsEmitted, SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceDeclaration.Name.ToString())));

--- a/src/Unitverse.Core/Helpers/Generate.cs
+++ b/src/Unitverse.Core/Helpers/Generate.cs
@@ -356,7 +356,7 @@
                     continue;
                 }
 
-                var fieldName = model.GetConstructorParameterFieldName(parameterModel);
+                var fieldName = model.GetConstructorParameterFieldName(parameterModel, frameworkSet.NamingProvider);
                 var typeSyntax = parameterModel.TypeInfo.ToTypeSyntax(frameworkSet.Context);
 
                 if (parameterModel.TypeInfo.Type.TypeKind == TypeKind.Interface)

--- a/src/Unitverse.Core/Options/INamingOptions.cs
+++ b/src/Unitverse.Core/Options/INamingOptions.cs
@@ -31,5 +31,9 @@
         string CannotCallOperatorWithNullNamingPattern { get; }
 
         string IsInitializedCorrectlyNamingPattern { get; }
+
+        string TargetFieldName { get; }
+
+        string DependencyFieldName { get; }
     }
 }

--- a/src/Unitverse.Core/Options/INamingProvider.cs
+++ b/src/Unitverse.Core/Options/INamingProvider.cs
@@ -31,5 +31,9 @@
         NameResolver CannotCallOperatorWithNull { get; }
 
         NameResolver IsInitializedCorrectly { get; }
+
+        NameResolver TargetFieldName { get; }
+
+        NameResolver DependencyFieldName { get; }
     }
 }

--- a/src/Unitverse.Core/Options/MutableNamingOptions.cs
+++ b/src/Unitverse.Core/Options/MutableNamingOptions.cs
@@ -26,6 +26,8 @@
             CanCallOperatorNamingPattern = options.CanCallOperatorNamingPattern;
             CannotCallOperatorWithNullNamingPattern = options.CannotCallOperatorWithNullNamingPattern;
             IsInitializedCorrectlyNamingPattern = options.IsInitializedCorrectlyNamingPattern;
+            TargetFieldName = options.TargetFieldName;
+            DependencyFieldName = options.DependencyFieldName;
         }
 
         public string CanCallNamingPattern { get; set; }
@@ -57,5 +59,9 @@
         public string CannotCallOperatorWithNullNamingPattern { get; set; }
 
         public string IsInitializedCorrectlyNamingPattern { get; set; }
+
+        public string TargetFieldName { get; set; }
+
+        public string DependencyFieldName { get; set; }
     }
 }

--- a/src/Unitverse.Core/Options/NameResolver.cs
+++ b/src/Unitverse.Core/Options/NameResolver.cs
@@ -1,9 +1,30 @@
 ﻿namespace Unitverse.Core.Options
 {
     using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Unitverse.Core.Helpers;
 
     public class NameResolver
     {
+        private static readonly Dictionary<string, Func<NamingContext, string>> TokenResolvers = new Dictionary<string, Func<NamingContext, string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "typeName", x => x.TypeName },
+            { "interfaceName", x => x.InterfaceName },
+            { "memberName", x => x.MemberName },
+            { "memberBareName", x => x.MemberBareName },
+            { "parameterName", x => x.ParameterName },
+            { "typeParameters", x => x.TypeParameters },
+        };
+
+        private static readonly Dictionary<string, Func<string, string>> Formatters = new Dictionary<string, Func<string, string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "lower", x => x.ToLowerInvariant() },
+            { "upper", x => x.ToUpperInvariant() },
+            { "camel", x => x.ToCamelCase() },
+            { "pascal", x => x.ToPascalCase() },
+        };
+
         private readonly string _pattern;
 
         public NameResolver(string pattern)
@@ -13,13 +34,64 @@
 
         public string Resolve(NamingContext context)
         {
-            return _pattern
-                .Replace("{typeName}", context.TypeName ?? string.Empty, StringComparison.OrdinalIgnoreCase)
-                .Replace("{interfaceName}", context.InterfaceName ?? string.Empty, StringComparison.OrdinalIgnoreCase)
-                .Replace("{memberName}", context.MemberName ?? string.Empty, StringComparison.OrdinalIgnoreCase)
-                .Replace("{memberBareName}", context.MemberBareName ?? string.Empty, StringComparison.OrdinalIgnoreCase)
-                .Replace("{parameterName}", context.ParameterName ?? string.Empty, StringComparison.OrdinalIgnoreCase)
-                .Replace("{typeParameters}", context.TypeParameters ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var output = new StringBuilder();
+            var token = new StringBuilder();
+            var formatter = new StringBuilder();
+
+            var inToken = false;
+            var inFormatter = false;
+            foreach (var c in _pattern)
+            {
+                if (c == '{')
+                {
+                    inToken = true;
+                    inFormatter = false;
+                }
+                else if (c == ':' && inToken)
+                {
+                    inFormatter = true;
+                }
+                else if (c == '}' && inToken)
+                {
+                    // emit token
+                    if (TokenResolvers.TryGetValue(token.ToString(), out var resolverFunc))
+                    {
+                        if (formatter.Length == 0 || !Formatters.TryGetValue(formatter.ToString(), out var formatterFunc))
+                        {
+                            formatterFunc = x => x;
+                        }
+
+                        output.Append(formatterFunc(resolverFunc(context)));
+                    }
+
+                    token.Clear();
+                    formatter.Clear();
+                    inToken = false;
+                    inFormatter = false;
+                }
+                else if (inToken)
+                {
+                    if (inFormatter)
+                    {
+                        formatter.Append(c);
+                    }
+                    else
+                    {
+                        token.Append(c);
+                    }
+                }
+                else
+                {
+                    output.Append(c);
+                }
+            }
+
+            return output.ToString();
         }
     }
 }

--- a/src/Unitverse.Core/Options/NamingProvider.cs
+++ b/src/Unitverse.Core/Options/NamingProvider.cs
@@ -45,5 +45,9 @@
         public NameResolver CannotCallOperatorWithNull => new NameResolver(_namingOptions.CannotCallOperatorWithNullNamingPattern);
 
         public NameResolver IsInitializedCorrectly => new NameResolver(_namingOptions.IsInitializedCorrectlyNamingPattern);
+
+        public NameResolver TargetFieldName => new NameResolver(_namingOptions.TargetFieldName);
+
+        public NameResolver DependencyFieldName => new NameResolver(_namingOptions.DependencyFieldName);
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
@@ -50,7 +50,7 @@
             }
 
             var variableDeclaration = SyntaxFactory.VariableDeclaration(model.TypeSyntax)
-                .AddVariables(SyntaxFactory.VariableDeclarator("_testClass"));
+                .AddVariables(SyntaxFactory.VariableDeclarator(model.TargetFieldName));
 
             var fieldDeclaration = SyntaxFactory.FieldDeclaration(variableDeclaration)
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/NotifyPropertyChangedGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/NotifyPropertyChangedGenerationStrategy.cs
@@ -85,7 +85,7 @@
 
             yield return SyntaxFactory.ExpressionStatement(
                 SyntaxFactory.InvocationExpression(
-                        SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName("_testClass"), SyntaxFactory.IdentifierName("CheckProperty")))
+                        SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, sourceModel.TargetInstance, SyntaxFactory.IdentifierName("CheckProperty")))
                     .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList<ArgumentSyntax>(argumentList))));
         }
     }

--- a/src/Unitverse.Specs/DefaultNamingOptions.cs
+++ b/src/Unitverse.Specs/DefaultNamingOptions.cs
@@ -33,5 +33,9 @@
         public string CanCallOperatorNamingPattern { get; set; } = "CanCall{memberName}Operator";
 
         public string CannotCallOperatorWithNullNamingPattern { get; set; } = "CannotCall{memberName}OperatorWithNull{parameterName}";
+
+        public string TargetFieldName { get; set; } = "_testClass";
+
+        public string DependencyFieldName { get; set; } = "_{parameterName:camel}";
     }
 }

--- a/src/Unitverse/Options/NamingOptions.cs
+++ b/src/Unitverse/Options/NamingOptions.cs
@@ -22,22 +22,22 @@ namespace Unitverse.Options
         [Description("Naming format for the constructor test that checks string null or white space guards")]
         public string CannotConstructWithInvalidNamingPattern { get; set; } = "CannotConstructWithInvalid{parameterName}";
 
-        [Category("Properties & Indexers")]
+        [Category("Properties && Indexers")]
         [DisplayName("CanGet")]
         [Description("Naming format for read-only property tests")]
         public string CanGetNamingPattern { get; set; } = "CanGet{memberName}";
 
-        [Category("Properties & Indexers")]
+        [Category("Properties && Indexers")]
         [DisplayName("CanSetAndGet")]
         [Description("Naming format for read-write property tests")]
         public string CanSetAndGetNamingPattern { get; set; } = "CanSetAndGet{memberName}";
 
-        [Category("Properties & Indexers")]
+        [Category("Properties && Indexers")]
         [DisplayName("CanSet")]
         [Description("Naming format for read-only property tests")]
         public string CanSetNamingPattern { get; set; } = "CanSet{memberName}";
 
-        [Category("Properties & Indexers")]
+        [Category("Properties && Indexers")]
         [DisplayName("IsInitializedCorrectly")]
         [Description("Naming format for tests that ensure properties are set correctly by the constructor")]
         public string IsInitializedCorrectlyNamingPattern { get; set; } = "{memberName}IsInitializedCorrectly";
@@ -81,5 +81,17 @@ namespace Unitverse.Options
         [DisplayName("CannotCallOperatorWithNull")]
         [Description("Naming format for the operator test that checks null guards")]
         public string CannotCallOperatorWithNullNamingPattern { get; set; } = "CannotCall{memberName}OperatorWithNull{parameterName}";
+
+        [Category("Fields")]
+        [DisplayName("Target Field Name")]
+        [Description("Naming format for the field name used for the instance being tested")]
+        public string TargetFieldName { get; set; } = "_testClass";
+
+
+        [Category("Fields")]
+        [DisplayName("Dependency Field Name")]
+        [Description("Naming format for the field name used for dependencies")]
+        public string DependencyFieldName { get; set; } = "_{parameterName:camel}";
+
     }
 }


### PR DESCRIPTION
This PR addresses the suggestions raised in #3.

It adds naming formats for the field that stores the target instance and for fields that hold constructor parameter dependencies.