### PR TITLE
Assertion improvements for xunit/FluentAssertions

### DIFF
--- a/src/Unitverse.Core.Tests/Frameworks/Test/TestFrameworkTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/Test/TestFrameworkTests.cs
@@ -42,7 +42,7 @@ namespace Unitverse.Core.Tests.Frameworks.Test
         [TestCase(TestFrameworkTypes.NUnit2, "Assert.Fail(\"TestValue538721341\");")]
         [TestCase(TestFrameworkTypes.NUnit3, "Assert.Fail(\"TestValue538721341\");")]
         [TestCase(TestFrameworkTypes.MsTest, "Assert.Fail(\"TestValue538721341\");")]
-        [TestCase(TestFrameworkTypes.XUnit, "Assert.True(false, \"TestValue538721341\");")]
+        [TestCase(TestFrameworkTypes.XUnit, "throw new NotImplementedException(\"TestValue538721341\");")]
         public void CanCallAssertFail(TestFrameworkTypes frameworkTypes, string expectedOutput)
         {
             var testClass = CreateFramework(frameworkTypes);

--- a/src/Unitverse.Core/Frameworks/Assertion/FluentAssertionFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Assertion/FluentAssertionFramework.cs
@@ -10,7 +10,14 @@
 
     public class FluentAssertionFramework : IAssertionFramework
     {
+        private readonly IAssertionFramework _baseFramework;
+
         public bool AssertThrowsAsyncIsAwaitable => true;
+
+        public FluentAssertionFramework(IAssertionFramework baseFramework)
+        {
+            _baseFramework = baseFramework ?? throw new ArgumentNullException(nameof(baseFramework));
+        }
 
         private static ExpressionSyntax Should(ExpressionSyntax actual)
         {
@@ -44,15 +51,7 @@
 
         public StatementSyntax AssertFail(string message)
         {
-            return SyntaxFactory.ExpressionStatement(
-                        SyntaxFactory.InvocationExpression(
-                            SyntaxFactory.MemberAccessExpression(
-                                SyntaxKind.SimpleMemberAccessExpression,
-                                Should(SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)),
-                                SyntaxFactory.IdentifierName("Be")))
-                        .WithArgumentList(
-                            Generate.Arguments(
-                                SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression), SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(message)))));
+            return _baseFramework.AssertFail(message);
         }
 
         public StatementSyntax AssertGreaterThan(ExpressionSyntax actual, ExpressionSyntax expected)

--- a/src/Unitverse.Core/Frameworks/FrameworkSetFactory.cs
+++ b/src/Unitverse.Core/Frameworks/FrameworkSetFactory.cs
@@ -20,7 +20,7 @@
             var context = new GenerationContext();
             var testFramework = Create(options.GenerationOptions.FrameworkType);
             IAssertionFramework assertionFramework = testFramework;
-            return new FrameworkSet(testFramework, Create(options.GenerationOptions.MockingFrameworkType, context), options.GenerationOptions.UseFluentAssertions ? new FluentAssertionFramework() : assertionFramework, new NamingProvider(options.NamingOptions), context, options.GenerationOptions.TestTypeNaming);
+            return new FrameworkSet(testFramework, Create(options.GenerationOptions.MockingFrameworkType, context), options.GenerationOptions.UseFluentAssertions ? new FluentAssertionFramework(assertionFramework) : assertionFramework, new NamingProvider(options.NamingOptions), context, options.GenerationOptions.TestTypeNaming);
         }
 
         private static IMockingFramework Create(MockingFrameworkType mockingFrameworkType, IGenerationContext context)

--- a/src/Unitverse.Core/Frameworks/Test/XUnitTestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/XUnitTestFramework.cs
@@ -40,7 +40,7 @@
                 throw new ArgumentNullException(nameof(message));
             }
 
-            return SyntaxFactory.ExpressionStatement(AssertCall("True").WithArgumentList(Generate.Arguments(Generate.Literal(false), Generate.Literal(message))));
+            return SyntaxFactory.ThrowStatement(Generate.ObjectCreation(SyntaxFactory.IdentifierName("NotImplementedException"), Generate.Literal(message)));
         }
 
         public StatementSyntax AssertGreaterThan(ExpressionSyntax actual, ExpressionSyntax expected)

--- a/src/Unitverse.Specs/FrameworkGeneration/FrameworkGeneration.feature
+++ b/src/Unitverse.Specs/FrameworkGeneration/FrameworkGeneration.feature
@@ -121,10 +121,10 @@ public class TestClass
 		And I expect it to contain the statement '<statement>'
 
 	Examples:
-	| framework | statement                                    |
-	| MsTest    | Assert.Fail("Create or modify test");        |
-	| NUnit3    | Assert.Fail("Create or modify test");        |
-	| XUnit     | Assert.True(false, "Create or modify test"); |
+	| framework | statement                                                   |
+	| MsTest    | Assert.Fail("Create or modify test");                       |
+	| NUnit3    | Assert.Fail("Create or modify test");                       |
+	| XUnit     | throw new NotImplementedException("Create or modify test"); |
 
 Scenario Outline: Framework Generation Test - AssertEqual
 	Given I have a class defined as 

--- a/src/Unitverse.Specs/FrameworkGeneration/FrameworkGeneration.feature.cs
+++ b/src/Unitverse.Specs/FrameworkGeneration/FrameworkGeneration.feature.cs
@@ -182,7 +182,7 @@ testing = 1
         [NUnit.Framework.DescriptionAttribute("Framework Generation Test - AssertFail")]
         [NUnit.Framework.TestCaseAttribute("MsTest", "Assert.Fail(\"Create or modify test\");", null)]
         [NUnit.Framework.TestCaseAttribute("NUnit3", "Assert.Fail(\"Create or modify test\");", null)]
-        [NUnit.Framework.TestCaseAttribute("XUnit", "Assert.True(false, \"Create or modify test\");", null)]
+        [NUnit.Framework.TestCaseAttribute("XUnit", "throw new NotImplementedException(\"Create or modify test\");", null)]
         public virtual void FrameworkGenerationTest_AssertFail(string framework, string statement, string[] exampleTags)
         {
             string[] tagsOfScenario = exampleTags;


### PR DESCRIPTION
Change xunit to throw NotImplementedException instead of Assert.True(false) for Assert.Fail

Change FluentAssertions to use base framework's Assert.Fail