### PR TITLE
Support for emitting tests for internal members

### DIFF
--- a/src/Unitverse.Core.Tests/ClassModelProvider.cs
+++ b/src/Unitverse.Core.Tests/ClassModelProvider.cs
@@ -5,8 +5,10 @@
     using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
+    using NSubstitute;
     using Unitverse.Core.Helpers;
     using Unitverse.Core.Models;
+    using Unitverse.Core.Options;
 
     internal static class ClassModelProvider
     {
@@ -69,7 +71,7 @@
             var semanticModel = compilation.GetSemanticModel(tree);
 
             var model = new TestableItemExtractor(semanticModel.SyntaxTree, semanticModel);
-            return model.Extract(null).First();
+            return model.Extract(null, Substitute.For<IUnitTestGeneratorOptions>()).First();
         }
 
         public static void Consume<T>(this IEnumerable<T> enumerable)

--- a/src/Unitverse.Core.Tests/Helpers/GenerateTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/GenerateTests.cs
@@ -256,7 +256,7 @@ namespace Unitverse.Core.Tests.Helpers
         public static void CanCallSetupMethod()
         {
             var extractor = new TestableItemExtractor(TestSemanticModelFactory.Tree, TestSemanticModelFactory.Model);
-            var model = extractor.Extract(null).First();
+            var model = extractor.Extract(null, Substitute.For<IUnitTestGeneratorOptions>()).First();
             var targetTypeName = "TestValue1540739065";
             var options = Substitute.For<IUnitTestGeneratorOptions>();
             options.NamingOptions.TargetFieldName.Returns("_testClass");

--- a/src/Unitverse.Core.Tests/Helpers/TestableItemExtractorTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/TestableItemExtractorTests.cs
@@ -3,8 +3,10 @@ namespace Unitverse.Core.Tests.Helpers
     using System;
     using System.Linq;
     using Microsoft.CodeAnalysis;
+    using NSubstitute;
     using NUnit.Framework;
     using Unitverse.Core.Helpers;
+    using Unitverse.Core.Options;
 
     [TestFixture]
     public class TestableItemExtractorTests
@@ -43,7 +45,7 @@ namespace Unitverse.Core.Tests.Helpers
         [Test]
         public void CanCallExtract()
         {
-            var result = _testClass.Extract(null).Single();
+            var result = _testClass.Extract(null, Substitute.For<IUnitTestGeneratorOptions>()).Single();
             Assert.That(result.Constructors.Count, Is.EqualTo(1));
             Assert.That(result.Methods.Count, Is.EqualTo(2));
             Assert.That(result.Indexers.Count, Is.EqualTo(1));
@@ -53,7 +55,7 @@ namespace Unitverse.Core.Tests.Helpers
         [Test]
         public void CanCallExtractWithMethodSymbol()
         {
-            var result = _testClass.Extract(TestSemanticModelFactory.Method).Single();
+            var result = _testClass.Extract(TestSemanticModelFactory.Method, Substitute.For<IUnitTestGeneratorOptions>()).Single();
             Assert.That(result.Constructors.Count(x => x.ShouldGenerate), Is.EqualTo(0));
             Assert.That(result.Methods.Count(x => x.ShouldGenerate), Is.EqualTo(1));
             Assert.That(result.Indexers.Count(x => x.ShouldGenerate), Is.EqualTo(0));
@@ -63,7 +65,7 @@ namespace Unitverse.Core.Tests.Helpers
         [Test]
         public void CanCallExtractWithConstructorSymbol()
         {
-            var result = _testClass.Extract(TestSemanticModelFactory.Constructor).Single();
+            var result = _testClass.Extract(TestSemanticModelFactory.Constructor, Substitute.For<IUnitTestGeneratorOptions>()).Single();
             Assert.That(result.Constructors.Count, Is.EqualTo(1));
             Assert.That(result.Methods.Count, Is.EqualTo(2));
             Assert.That(result.Indexers.Count, Is.EqualTo(1));
@@ -77,7 +79,7 @@ namespace Unitverse.Core.Tests.Helpers
         [Test]
         public void CanCallExtractWithPropertySymbol()
         {
-            var result = _testClass.Extract(TestSemanticModelFactory.Property).Single();
+            var result = _testClass.Extract(TestSemanticModelFactory.Property, Substitute.For<IUnitTestGeneratorOptions>()).Single();
             Assert.That(result.Constructors.Count, Is.EqualTo(1));
             Assert.That(result.Methods.Count, Is.EqualTo(2));
             Assert.That(result.Indexers.Count, Is.EqualTo(1));
@@ -91,7 +93,7 @@ namespace Unitverse.Core.Tests.Helpers
         [Test]
         public void CanCallExtractWithIndexerSymbol()
         {
-            var result = _testClass.Extract(TestSemanticModelFactory.Indexer).Single();
+            var result = _testClass.Extract(TestSemanticModelFactory.Indexer, Substitute.For<IUnitTestGeneratorOptions>()).Single();
             Assert.That(result.Constructors.Count, Is.EqualTo(1));
             Assert.That(result.Methods.Count, Is.EqualTo(2));
             Assert.That(result.Indexers.Count, Is.EqualTo(1));
@@ -105,7 +107,7 @@ namespace Unitverse.Core.Tests.Helpers
         [Test]
         public void CanCallExtractWithTypeSymbol()
         {
-            var result = _testClass.Extract(TestSemanticModelFactory.Class).Single();
+            var result = _testClass.Extract(TestSemanticModelFactory.Class, Substitute.For<IUnitTestGeneratorOptions>()).Single();
             Assert.That(result.Constructors.Count, Is.EqualTo(1));
             Assert.That(result.Methods.Count, Is.EqualTo(2));
             Assert.That(result.Indexers.Count, Is.EqualTo(1));

--- a/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/ComparableGenerationStrategyTests.cs
+++ b/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/ComparableGenerationStrategyTests.cs
@@ -56,7 +56,7 @@ namespace Unitverse.Core.Tests.Strategies.InterfaceGeneration
             var syntaxTree = TestSemanticModelFactory.CreateTree(TestClasses.IComparableTestFile);
             var model = TestSemanticModelFactory.CreateSemanticModel(syntaxTree);
             var extractor = new TestableItemExtractor(syntaxTree, model);
-            var classModel = extractor.Extract(syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First()).First();
+            var classModel = extractor.Extract(syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First(), Substitute.For<IUnitTestGeneratorOptions>()).First();
 
             var result = _testClass.Create(classModel, classModel, new NamingContext("class"));
 

--- a/src/Unitverse.Core.Tests/UnitTestGeneratorTests.cs
+++ b/src/Unitverse.Core.Tests/UnitTestGeneratorTests.cs
@@ -167,7 +167,7 @@
 
             var extractor = new TestableItemExtractor(tree, semanticModel);
 
-            var classModels = extractor.Extract(methodSyntax);
+            var classModels = extractor.Extract(methodSyntax, Substitute.For<IUnitTestGeneratorOptions>());
             var classModel = classModels.FirstOrDefault();
 
             Assert.That(classModel, Is.Not.Null);

--- a/src/Unitverse.Core/CoreGenerator.cs
+++ b/src/Unitverse.Core/CoreGenerator.cs
@@ -392,7 +392,7 @@
             var frameworkSet = FrameworkSetFactory.Create(options);
 
             var model = new TestableItemExtractor(sourceModel.SyntaxTree, sourceModel);
-            var classModels = model.Extract(sourceSymbol).ToList();
+            var classModels = model.Extract(sourceSymbol, options).ToList();
 
             foreach (var c in classModels)
             {

--- a/src/Unitverse.Core/Helpers/DetectedGenerationOptions.cs
+++ b/src/Unitverse.Core/Helpers/DetectedGenerationOptions.cs
@@ -36,5 +36,7 @@
         public bool EmitUsingsOutsideNamespace => _baseOptions.EmitUsingsOutsideNamespace;
 
         public bool PartialGenerationAllowed => _baseOptions.PartialGenerationAllowed;
+
+        public bool EmitTestsForInternals => _baseOptions.EmitTestsForInternals;
     }
 }

--- a/src/Unitverse.Core/Options/IGenerationOptions.cs
+++ b/src/Unitverse.Core/Options/IGenerationOptions.cs
@@ -21,5 +21,7 @@
         bool EmitUsingsOutsideNamespace { get; }
 
         bool PartialGenerationAllowed { get; }
+
+        bool EmitTestsForInternals { get; }
     }
 }

--- a/src/Unitverse.Core/Options/MutableGenerationOptions.cs
+++ b/src/Unitverse.Core/Options/MutableGenerationOptions.cs
@@ -21,6 +21,7 @@
             AutoDetectFrameworkTypes = options.AutoDetectFrameworkTypes;
             EmitUsingsOutsideNamespace = options.EmitUsingsOutsideNamespace;
             PartialGenerationAllowed = options.PartialGenerationAllowed;
+            EmitTestsForInternals = options.EmitTestsForInternals;
         }
 
         public TestFrameworkTypes FrameworkType { get; set; }
@@ -42,5 +43,7 @@
         public bool EmitUsingsOutsideNamespace { get; set; }
 
         public bool PartialGenerationAllowed { get; set; }
+
+        public bool EmitTestsForInternals { get; set; }
     }
 }

--- a/src/Unitverse.Specs/BaseSteps.cs
+++ b/src/Unitverse.Specs/BaseSteps.cs
@@ -26,7 +26,7 @@
             _context.SemanticModel = model;
 
             var extractor = new TestableItemExtractor(syntaxTree, model);
-            _context.ClassModel = extractor.Extract(syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First()).First();
+            _context.ClassModel = extractor.Extract(syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First(), new UnitTestGeneratorOptions(new GenerationOptions(TestFrameworkTypes.NUnit3, MockingFrameworkType.NSubstitute), new DefaultNamingOptions(), false)).First();
         }
 
         [Given(@"I set my test framework to '(.*)'")]

--- a/src/Unitverse.Specs/GenerationOptions.cs
+++ b/src/Unitverse.Specs/GenerationOptions.cs
@@ -27,5 +27,7 @@
         public bool EmitUsingsOutsideNamespace { get; }
 
         public bool PartialGenerationAllowed { get; } = false;
+
+        public bool EmitTestsForInternals { get; } = false;
     }
 }

--- a/src/Unitverse/Options/GenerationOptions.cs
+++ b/src/Unitverse/Options/GenerationOptions.cs
@@ -53,8 +53,13 @@
         public bool EmitUsingsOutsideNamespace { get; set; } = false;
 
         [Category("Generation")]
-        [DisplayName("Partial Generation")]
+        [DisplayName("Partial generation")]
         [Description("When enabled, any new test methods are allowed to be added to the target test class without causing an error")]
         public bool PartialGenerationAllowed { get; set; } = true;
+
+        [Category("Generation")]
+        [DisplayName("Emit tests for internal members")]
+        [Description("Whether to emit tests for members marked as internal as well as public members")]
+        public bool EmitTestsForInternals { get; set; } = false;
     }
 }


### PR DESCRIPTION
Option to allow picking out methods to test that have `internal` visibility, addresses #16 