### PR TITLE
Added inherited test class generation for protected members

### DIFF
--- a/src/Unitverse.Core.Tests/DefaultGenerationOptions.cs
+++ b/src/Unitverse.Core.Tests/DefaultGenerationOptions.cs
@@ -1,0 +1,29 @@
+﻿namespace Unitverse.Core.Tests
+{
+    using Unitverse.Core.Options;
+
+    public class DefaultGenerationOptions : IGenerationOptions
+    {
+        public TestFrameworkTypes FrameworkType => TestFrameworkTypes.XUnit;
+
+        public MockingFrameworkType MockingFrameworkType => MockingFrameworkType.NSubstitute;
+
+        public bool UseFluentAssertions => false;
+
+        public bool AutoDetectFrameworkTypes => false;
+
+        public bool AllowGenerationWithoutTargetProject => false;
+
+        public string TestProjectNaming => "{0}.Tests";
+
+        public string TestFileNaming => "{0}Tests";
+
+        public string TestTypeNaming => "{0}Tests";
+
+        public bool EmitUsingsOutsideNamespace => false;
+
+        public bool PartialGenerationAllowed => false;
+
+        public bool EmitTestsForInternals => false;
+    }
+}

--- a/src/Unitverse.Core.Tests/Resources/ProtectedClassNoInternal.txt
+++ b/src/Unitverse.Core.Tests/Resources/ProtectedClassNoInternal.txt
@@ -1,0 +1,21 @@
+// # EmitTestsForInternals=false
+namespace TestNamespace
+{
+    public class TestClass
+    {
+	    public void ThisIsAMethod(string methodName, int methodValue)
+	    {
+		    System.Console.WriteLine("Testing this");
+	    }
+
+	    protected void ThisIsAMethodProtected(string methodName, int methodValue)
+	    {
+		    System.Console.WriteLine("Testing this");
+	    }
+
+	    protected internal void ThisIsAMethodProtectedInternal(string methodName, int methodValue)
+	    {
+		    System.Console.WriteLine("Testing this");
+	    }
+    }
+}

--- a/src/Unitverse.Core.Tests/Resources/ProtectedClassNoInternal1.txt
+++ b/src/Unitverse.Core.Tests/Resources/ProtectedClassNoInternal1.txt
@@ -1,0 +1,21 @@
+// # EmitTestsForInternals=true
+namespace TestNamespace
+{
+    public class TestClass
+    {
+	    public void ThisIsAMethod(string methodName, int methodValue)
+	    {
+		    System.Console.WriteLine("Testing this");
+	    }
+
+	    protected void ThisIsAMethodProtected(string methodName, int methodValue)
+	    {
+		    System.Console.WriteLine("Testing this");
+	    }
+
+	    protected internal void ThisIsAMethodProtectedInternal(string methodName, int methodValue)
+	    {
+		    System.Console.WriteLine("Testing this");
+	    }
+    }
+}

--- a/src/Unitverse.Core.Tests/TestClasses.resx
+++ b/src/Unitverse.Core.Tests/TestClasses.resx
@@ -226,6 +226,12 @@
   <data name="PropertyChangeTestFile" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\PropertyChangeTestFile.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="ProtectedClassInternal" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\ProtectedClassNoInternal1.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="ProtectedClassNoInternal" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\ProtectedClassNoInternal.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;iso-8859-1</value>
+  </data>
   <data name="RefAndOutParameters" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\RefAndOutParameters.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/Unitverse.Core/Strategies/ClassGeneration/AbstractClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/AbstractClassGenerationStrategy.cs
@@ -30,7 +30,12 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            return model.Declaration.Modifiers.Any(x => string.Equals(x.Text, "abstract", StringComparison.OrdinalIgnoreCase));
+            if (model.Declaration.Modifiers.Any(x => string.Equals(x.Text, "abstract", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+
+            return model.Methods.Any(x => x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)));
         }
 
         public ClassDeclarationSyntax Create(ClassModel model)

--- a/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
@@ -27,8 +27,13 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            return !model.Declaration.Modifiers.Any(x => string.Equals(x.Text, "static", StringComparison.OrdinalIgnoreCase) ||
-                                                         string.Equals(x.Text, "abstract", StringComparison.OrdinalIgnoreCase));
+            if (model.Declaration.Modifiers.Any(x => string.Equals(x.Text, "static", StringComparison.OrdinalIgnoreCase) ||
+                                                     string.Equals(x.Text, "abstract", StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            return model.Methods.All(x => !x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)));
         }
 
         public ClassDeclarationSyntax Create(ClassModel model)


### PR DESCRIPTION
If a source type has protected members, the abstract generation strategy is now used to create an inheriting class that allows the protected members to be called. Addresses #20 