### PR TITLE
Slight documentation updates, build protection for examples

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,9 @@ jobs:
       run: msbuild $env:SolutionPath /t:Rebuild -v:m 
       env: 
         DeployExtension: False
+    - run: |
+        ./.github/workflows/CheckChanges.ps1
+      shell: pwsh 
     - name: Test extension
       run: dotnet test --no-build --verbosity minimal $env:SolutionPath
     - name: Collect artifacts - VSIX

--- a/.github/workflows/CheckChanges.ps1
+++ b/.github/workflows/CheckChanges.ps1
@@ -1,0 +1,11 @@
+$Changes = @()
+$Changes += git status docs/ --porcelain
+
+if ($Changes.count -gt 0)
+{
+	Exit 1
+}
+else
+{
+    Exit 0
+}

--- a/MarketplaceOverview.md
+++ b/MarketplaceOverview.md
@@ -4,6 +4,8 @@
 ## Introduction
 The Unitverse extension generates tests for classes written in C#. The extension covers basic tests automatically (for example, checking for correct property initialization), and creates placeholder tests for methods. Unitverse aims to produce tests that compile, so that you can generate tests as you code, but still focus on what you are doing rather than divert your attention to fixing broken generated code. Unitverse also allows incremental test generation - as you add new members to your types you can add tests for those new members quickly through the editor. Also, if you refactor methods or constructor signatures, you can regenerate those tests quickly and easily.
 
+For more in-depth documentation, visit the [documentation on the readthedocs.io](https://unitverse.readthedocs.io/).
+
 ## Using the Extension
 
 Using the code editor context menu:
@@ -35,5 +37,3 @@ FluentAssertions can also be used for assertions, replacing the assertions built
 ### Framework Auto-Detection
 
 If Unitverse finds a test project related to the source project, it will look at the project references to determine what test and mocking frameworks to use. It will automatically use FluentAssertions if present. You can turn off framework auto-detection by going to Tools->Options->Unitverse.
-
-For more in-depth documentation, visit the [documentation on the readthedocs.io](https://unitverse.readthedocs.io/).

--- a/docs/examples/AbstractClass.md
+++ b/docs/examples/AbstractClass.md
@@ -1,6 +1,8 @@
 ﻿## AbstractClass
 Demonstrates how Unitverse generates tests when the source class is abstract or contains protected methods, as well as how inheritance chains are accounted for
 
+test broken bit
+
 ### Source Type(s)
 ``` csharp
 public abstract class TestClass

--- a/docs/examples/AbstractClass.md
+++ b/docs/examples/AbstractClass.md
@@ -1,8 +1,6 @@
 ﻿## AbstractClass
 Demonstrates how Unitverse generates tests when the source class is abstract or contains protected methods, as well as how inheritance chains are accounted for
 
-test broken bit
-
 ### Source Type(s)
 ``` csharp
 public abstract class TestClass

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+![Latest release](https://img.shields.io/github/v/release/mattwhitfield/unittestgenerator?color=00A000) ![Last commit](https://img.shields.io/github/last-commit/mattwhitfield/unittestgenerator?color=00A000) ![Build status](https://img.shields.io/github/workflow/status/mattwhitfield/unittestgenerator/Extension%20build) ![Open issue count](https://img.shields.io/github/issues/mattwhitfield/unittestgenerator)
+
 # Introduction
 The Unitverse Visual Studio extension generates tests for classes written in C#. The extension covers basic tests automatically (for example, checking for correct property initialization), and creates placeholder tests for methods. Unitverse aims to produce tests that compile, so that you can generate tests as you code, but still focus on what you are doing rather than divert your attention to fixing broken generated code. Unitverse also allows incremental test generation - as you add new members to your types you can add tests for those new members quickly through the editor. Also, if you refactor methods or constructor signatures, you can regenerate those tests quickly and easily.
 


### PR DESCRIPTION
Slight documentation updates, adding protection to break the build if the checked in examples don't match what is generated during the build

Resolves #32 