### PR TITLE
Support for record types, better organisation of examples

### DIFF
--- a/docs/examples/AbstractClass.md
+++ b/docs/examples/AbstractClass.md
@@ -1,4 +1,4 @@
-﻿## AbstractClass
+﻿## Abstract Classes
 Demonstrates how Unitverse generates tests when the source class is abstract or contains protected methods, as well as how inheritance chains are accounted for
 
 ### Source Type(s)

--- a/docs/examples/AsyncMethod.md
+++ b/docs/examples/AsyncMethod.md
@@ -1,4 +1,4 @@
-﻿## AsyncMethod
+﻿## Async Methods
 Demonstrates how tests are generated for async methods, as well as showing how the assertion framework is driven differently for async methods
 
 ### Source Type(s)

--- a/docs/examples/AutomaticMockGeneration.md
+++ b/docs/examples/AutomaticMockGeneration.md
@@ -1,4 +1,4 @@
-﻿## AutomaticMockGeneration
+﻿## Automatic Mock Generation
 Demonstrates how dependencies injected into constructors are tracked, and mock configuration calls emitted for any detected dependencies
 
 ### Source Type(s)

--- a/docs/examples/ConstrainedGenericType.md
+++ b/docs/examples/ConstrainedGenericType.md
@@ -1,4 +1,4 @@
-﻿## ConstrainedGenericType
+﻿## Constrained Generic Types
 Demonstrates how appropriate types are selected for the generation of tests for generic types with type constraints
 
 ### Source Type(s)

--- a/docs/examples/DelegateGeneration.md
+++ b/docs/examples/DelegateGeneration.md
@@ -1,4 +1,4 @@
-﻿## DelegateGeneration
+﻿## Delegate Generation
 Demonstrates how Unitverse generates default values for method parameters when the parameter is a delegate type
 
 ### Source Type(s)

--- a/docs/examples/ExtensionMethod.md
+++ b/docs/examples/ExtensionMethod.md
@@ -1,4 +1,4 @@
-﻿## ExtensionMethod
+﻿## Extension Methods
 Demonstrates how Unitverse generates tests for extension methods
 
 ### Source Type(s)

--- a/docs/examples/FrameworksFluentAssertions.md
+++ b/docs/examples/FrameworksFluentAssertions.md
@@ -1,4 +1,4 @@
-﻿## FrameworksFluentAssertions
+﻿## Frameworks - Fluent Assertions
 Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework. Also shows using FluentAssertions for the assertion framework.
 
 ### Source Type(s)

--- a/docs/examples/FrameworksMsTestMoq.md
+++ b/docs/examples/FrameworksMsTestMoq.md
@@ -1,4 +1,4 @@
-﻿## FrameworksMsTestMoq
+﻿## Frameworks - MSTest & Moq
 Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework
 
 ### Source Type(s)

--- a/docs/examples/FrameworksNUnitFakeItEasy.md
+++ b/docs/examples/FrameworksNUnitFakeItEasy.md
@@ -1,4 +1,4 @@
-﻿## FrameworksNUnitFakeItEasy
+﻿## Frameworks - NUnit 3 & FakeItEasy
 Demonstrates how tests are generated using NUnit 3 for the test framework and FakeItEasy for the mocking framework
 
 ### Source Type(s)

--- a/docs/examples/FrameworksXUnitNSubstitute.md
+++ b/docs/examples/FrameworksXUnitNSubstitute.md
@@ -1,4 +1,4 @@
-﻿## FrameworksXUnitNSubstitute
+﻿## Frameworks - XUnit & NSubstitute
 Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework
 
 ### Source Type(s)

--- a/docs/examples/GenericMethod.md
+++ b/docs/examples/GenericMethod.md
@@ -1,4 +1,4 @@
-﻿## GenericMethod
+﻿## Generic Methods
 Demonstrates how Unitverse generates tests for generic methods
 
 ### Source Type(s)

--- a/docs/examples/IComparableTests.md
+++ b/docs/examples/IComparableTests.md
@@ -1,4 +1,4 @@
-﻿## IComparableTests
+﻿## IComparable
 Demonstrates the tests generated for a type that implements IComparable
 
 ### Source Type(s)

--- a/docs/examples/IndexerTests.md
+++ b/docs/examples/IndexerTests.md
@@ -1,4 +1,4 @@
-﻿## IndexerTests
+﻿## Indexers
 Demonstrates the tests generated for a type that contains an indexer
 
 ### Source Type(s)

--- a/docs/examples/MappingMethod.md
+++ b/docs/examples/MappingMethod.md
@@ -1,4 +1,4 @@
-﻿## MappingMethod
+﻿## Mapping Methods
 Shows how unitverse generates a test to verify mappings between input parameter type and return type where the types share property names
 
 ### Source Type(s)

--- a/docs/examples/MultipleOverloads.md
+++ b/docs/examples/MultipleOverloads.md
@@ -1,4 +1,4 @@
-﻿## MultipleOverloads
+﻿## Multiple Overloads
 Shows how unitverse generates unambiguous names for methods that test multiple overloads of the same source method
 
 ### Source Type(s)

--- a/docs/examples/NullableReferenceTypes.md
+++ b/docs/examples/NullableReferenceTypes.md
@@ -1,4 +1,4 @@
-﻿## NullableReferenceTypes
+﻿## Nullable Reference Types
 Shows how Unitverse will omit `null` tests for parameters declared to explicitly accept null
 
 ### Source Type(s)

--- a/docs/examples/OperatorOverloading.md
+++ b/docs/examples/OperatorOverloading.md
@@ -1,4 +1,4 @@
-﻿## OperatorOverloading
+﻿## Operator Overloading
 Shows how Unitverse emits tests for declared unary and binary operators
 
 ### Source Type(s)

--- a/docs/examples/PocoInitialization.md
+++ b/docs/examples/PocoInitialization.md
@@ -1,4 +1,4 @@
-﻿## PocoInitialization
+﻿## POCO Initialization
 Demonstrates how test values are produced to initialize POCO members when the type is consumed
 
 ### Source Type(s)

--- a/docs/examples/RecordTypeInitProperties.md
+++ b/docs/examples/RecordTypeInitProperties.md
@@ -1,0 +1,123 @@
+﻿## Record Types (init Properties)
+Demonstrates the tests generated for a record type that has properties that have init accessors
+
+### Source Type(s)
+``` csharp
+record Person
+{
+    private readonly string _firstName;
+    private readonly string _lastName;
+
+    public Guid Id { get; init; }
+
+    public string FirstName
+    {
+        get => _firstName;
+        init => _firstName = (value ?? throw new ArgumentNullException(nameof(value)));
+    }
+
+    public string? MiddleName { get; init; }
+
+    public string LastName
+    {
+        get => _lastName;
+        init => _lastName = (value ?? throw new ArgumentNullException(nameof(value)));
+    }
+
+    public IList<string> IceCreamFlavours { get; init; }
+}
+
+```
+
+### Generated Tests
+``` csharp
+public class PersonTests
+{
+    private Person _testClass;
+    private Guid _id;
+    private string _firstName;
+    private string _middleName;
+    private string _lastName;
+    private IList<string> _iceCreamFlavours;
+
+    public PersonTests()
+    {
+        _id = new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4");
+        _firstName = "TestValue607156385";
+        _middleName = "TestValue1321446349";
+        _lastName = "TestValue1512368656";
+        _iceCreamFlavours = Substitute.For<IList<string>>();
+        _testClass = new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours };
+    }
+
+    [Fact]
+    public void CanInitialize()
+    {
+        var instance = new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours };
+        instance.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CannotInitializeWithNullIceCreamFlavours()
+    {
+        FluentActions.Invoking(() => new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = default(IList<string>) }).Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CannotInitializeWithInvalidFirstName(string value)
+    {
+        FluentActions.Invoking(() => new Person { Id = _id, FirstName = value, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours }).Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CannotInitializeWithInvalidMiddleName(string value)
+    {
+        FluentActions.Invoking(() => new Person { Id = _id, FirstName = _firstName, MiddleName = value, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours }).Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CannotInitializeWithInvalidLastName(string value)
+    {
+        FluentActions.Invoking(() => new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = value, IceCreamFlavours = _iceCreamFlavours }).Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void IdIsInitializedCorrectly()
+    {
+        _testClass.Id.Should().Be(_id);
+    }
+
+    [Fact]
+    public void FirstNameIsInitializedCorrectly()
+    {
+        _testClass.FirstName.Should().BeSameAs(_firstName);
+    }
+
+    [Fact]
+    public void MiddleNameIsInitializedCorrectly()
+    {
+        _testClass.MiddleName.Should().BeSameAs(_middleName);
+    }
+
+    [Fact]
+    public void LastNameIsInitializedCorrectly()
+    {
+        _testClass.LastName.Should().BeSameAs(_lastName);
+    }
+
+    [Fact]
+    public void IceCreamFlavoursIsInitializedCorrectly()
+    {
+        _testClass.IceCreamFlavours.Should().BeSameAs(_iceCreamFlavours);
+    }
+}
+
+```

--- a/docs/examples/RecordTypesPrimaryConstructor.md
+++ b/docs/examples/RecordTypesPrimaryConstructor.md
@@ -1,0 +1,45 @@
+﻿## Record Types (Primary Constructor)
+Demonstrates the tests generated for a simple primary constructor record type
+
+### Source Type(s)
+``` csharp
+public record RecordType(string StringProperty, int IntProperty);
+
+```
+
+### Generated Tests
+``` csharp
+public class RecordTypeTests
+{
+    private RecordType _testClass;
+    private string _stringProperty;
+    private int _intProperty;
+
+    public RecordTypeTests()
+    {
+        _stringProperty = "TestValue534011718";
+        _intProperty = 237820880;
+        _testClass = new RecordType(_stringProperty, _intProperty);
+    }
+
+    [Fact]
+    public void CanConstruct()
+    {
+        var instance = new RecordType(_stringProperty, _intProperty);
+        instance.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void StringPropertyIsInitializedCorrectly()
+    {
+        _testClass.StringProperty.Should().BeSameAs(_stringProperty);
+    }
+
+    [Fact]
+    public void IntPropertyIsInitializedCorrectly()
+    {
+        _testClass.IntProperty.Should().Be(_intProperty);
+    }
+}
+
+```

--- a/docs/examples/RefAndOutParameters.md
+++ b/docs/examples/RefAndOutParameters.md
@@ -1,4 +1,4 @@
-﻿## RefAndOutParameters
+﻿## ref & out Parameters
 Demonstrates the tests that Unitverse emits when methods contain `ref` or `out` parameters
 
 ### Source Type(s)

--- a/docs/examples/SimplePoco.md
+++ b/docs/examples/SimplePoco.md
@@ -1,4 +1,4 @@
-﻿## SimplePoco
+﻿## Simple POCO
 Demonstrates how tests are generated for a simple POCO type
 
 ### Source Type(s)

--- a/docs/examples/Singleton.md
+++ b/docs/examples/Singleton.md
@@ -1,4 +1,4 @@
-﻿## Singleton
+﻿## Singletons
 Demonstrates how Unitverse attempts to use a static property to get a type instance when the constructor is private
 
 ### Source Type(s)

--- a/docs/examples/StaticClass.md
+++ b/docs/examples/StaticClass.md
@@ -1,4 +1,4 @@
-﻿## StaticClass
+﻿## Static Classes
 Demonstrates how Unitverse generates tests when the source class is static
 
 ### Source Type(s)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,27 +1,29 @@
-﻿# Examples
+﻿# Examples Overview
 This section contains examples of the output that Unitverse outputs, refreshed every build. Each example aims to demonstrate a particular scenario which is described in the following table.
 
 | Example | Description |
 | --- | --- |
-| [AbstractClass](examples/AbstractClass.md) | Demonstrates how Unitverse generates tests when the source class is abstract or contains protected methods, as well as how inheritance chains are accounted for |
-| [AsyncMethod](examples/AsyncMethod.md) | Demonstrates how tests are generated for async methods, as well as showing how the assertion framework is driven differently for async methods |
-| [AutomaticMockGeneration](examples/AutomaticMockGeneration.md) | Demonstrates how dependencies injected into constructors are tracked, and mock configuration calls emitted for any detected dependencies |
-| [ConstrainedGenericType](examples/ConstrainedGenericType.md) | Demonstrates how appropriate types are selected for the generation of tests for generic types with type constraints |
-| [DelegateGeneration](examples/DelegateGeneration.md) | Demonstrates how Unitverse generates default values for method parameters when the parameter is a delegate type |
-| [ExtensionMethod](examples/ExtensionMethod.md) | Demonstrates how Unitverse generates tests for extension methods |
-| [FrameworksFluentAssertions](examples/FrameworksFluentAssertions.md) | Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework. Also shows using FluentAssertions for the assertion framework. |
-| [FrameworksMsTestMoq](examples/FrameworksMsTestMoq.md) | Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework |
-| [FrameworksNUnitFakeItEasy](examples/FrameworksNUnitFakeItEasy.md) | Demonstrates how tests are generated using NUnit 3 for the test framework and FakeItEasy for the mocking framework |
-| [FrameworksXUnitNSubstitute](examples/FrameworksXUnitNSubstitute.md) | Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework |
-| [GenericMethod](examples/GenericMethod.md) | Demonstrates how Unitverse generates tests for generic methods |
-| [IComparableTests](examples/IComparableTests.md) | Demonstrates the tests generated for a type that implements IComparable |
-| [IndexerTests](examples/IndexerTests.md) | Demonstrates the tests generated for a type that contains an indexer |
-| [MappingMethod](examples/MappingMethod.md) | Shows how unitverse generates a test to verify mappings between input parameter type and return type where the types share property names |
-| [MultipleOverloads](examples/MultipleOverloads.md) | Shows how unitverse generates unambiguous names for methods that test multiple overloads of the same source method |
-| [NullableReferenceTypes](examples/NullableReferenceTypes.md) | Shows how Unitverse will omit `null` tests for parameters declared to explicitly accept null |
-| [OperatorOverloading](examples/OperatorOverloading.md) | Shows how Unitverse emits tests for declared unary and binary operators |
-| [PocoInitialization](examples/PocoInitialization.md) | Demonstrates how test values are produced to initialize POCO members when the type is consumed |
-| [RefAndOutParameters](examples/RefAndOutParameters.md) | Demonstrates the tests that Unitverse emits when methods contain `ref` or `out` parameters |
-| [SimplePoco](examples/SimplePoco.md) | Demonstrates how tests are generated for a simple POCO type |
-| [Singleton](examples/Singleton.md) | Demonstrates how Unitverse attempts to use a static property to get a type instance when the constructor is private |
-| [StaticClass](examples/StaticClass.md) | Demonstrates how Unitverse generates tests when the source class is static |
+| [Abstract Classes](AbstractClass.md) | Demonstrates how Unitverse generates tests when the source class is abstract or contains protected methods, as well as how inheritance chains are accounted for |
+| [Async Methods](AsyncMethod.md) | Demonstrates how tests are generated for async methods, as well as showing how the assertion framework is driven differently for async methods |
+| [Automatic Mock Generation](AutomaticMockGeneration.md) | Demonstrates how dependencies injected into constructors are tracked, and mock configuration calls emitted for any detected dependencies |
+| [Constrained Generic Types](ConstrainedGenericType.md) | Demonstrates how appropriate types are selected for the generation of tests for generic types with type constraints |
+| [Delegate Generation](DelegateGeneration.md) | Demonstrates how Unitverse generates default values for method parameters when the parameter is a delegate type |
+| [Extension Methods](ExtensionMethod.md) | Demonstrates how Unitverse generates tests for extension methods |
+| [Frameworks - Fluent Assertions](FrameworksFluentAssertions.md) | Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework. Also shows using FluentAssertions for the assertion framework. |
+| [Frameworks - MSTest & Moq](FrameworksMsTestMoq.md) | Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework |
+| [Frameworks - NUnit 3 & FakeItEasy](FrameworksNUnitFakeItEasy.md) | Demonstrates how tests are generated using NUnit 3 for the test framework and FakeItEasy for the mocking framework |
+| [Frameworks - XUnit & NSubstitute](FrameworksXUnitNSubstitute.md) | Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework |
+| [Generic Methods](GenericMethod.md) | Demonstrates how Unitverse generates tests for generic methods |
+| [IComparable](IComparableTests.md) | Demonstrates the tests generated for a type that implements IComparable |
+| [Indexers](IndexerTests.md) | Demonstrates the tests generated for a type that contains an indexer |
+| [Mapping Methods](MappingMethod.md) | Shows how unitverse generates a test to verify mappings between input parameter type and return type where the types share property names |
+| [Multiple Overloads](MultipleOverloads.md) | Shows how unitverse generates unambiguous names for methods that test multiple overloads of the same source method |
+| [Nullable Reference Types](NullableReferenceTypes.md) | Shows how Unitverse will omit `null` tests for parameters declared to explicitly accept null |
+| [Operator Overloading](OperatorOverloading.md) | Shows how Unitverse emits tests for declared unary and binary operators |
+| [POCO Initialization](PocoInitialization.md) | Demonstrates how test values are produced to initialize POCO members when the type is consumed |
+| [Record Types (init Properties)](RecordTypeInitProperties.md) | Demonstrates the tests generated for a record type that has properties that have init accessors |
+| [Record Types (Primary Constructor)](RecordTypesPrimaryConstructor.md) | Demonstrates the tests generated for a simple primary constructor record type |
+| [ref & out Parameters](RefAndOutParameters.md) | Demonstrates the tests that Unitverse emits when methods contain `ref` or `out` parameters |
+| [Simple POCO](SimplePoco.md) | Demonstrates how tests are generated for a simple POCO type |
+| [Singletons](Singleton.md) | Demonstrates how Unitverse attempts to use a static property to get a type instance when the constructor is private |
+| [Static Classes](StaticClass.md) | Demonstrates how Unitverse generates tests when the source class is static |

--- a/src/Unitverse.Core.Tests/DefaultNamingOptions.cs
+++ b/src/Unitverse.Core.Tests/DefaultNamingOptions.cs
@@ -10,6 +10,12 @@
 
         public string CannotConstructWithInvalidNamingPattern { get; set; } = "CannotConstructWithInvalid{parameterName}";
 
+        public string CanInitializeNamingPattern { get; set; } = "CanInitialize";
+
+        public string CannotInitializeWithNullNamingPattern { get; set; } = "CannotInitializeWithNull{memberName}";
+
+        public string CannotInitializeWithInvalidNamingPattern { get; set; } = "CannotInitializeWithInvalid{memberName}";
+
         public string CanGetNamingPattern { get; set; } = "CanGet{memberName}";
 
         public string CanSetAndGetNamingPattern { get; set; } = "CanSetAndGet{memberName}";

--- a/src/Unitverse.Core.Tests/Models/PropertyModelTests.cs
+++ b/src/Unitverse.Core.Tests/Models/PropertyModelTests.cs
@@ -22,26 +22,26 @@ namespace Unitverse.Core.Tests.Models
             _name = "TestValue1619496715";
             _node = TestSemanticModelFactory.Property;
             _typeInfo = default(TypeInfo);
-            _testClass = new PropertyModel(_name, _node, _typeInfo, Substitute.For<SemanticModel>());
+            _testClass = new PropertyModel(_name, _node, _typeInfo, Substitute.For<SemanticModel>(), null);
         }
 
         [Test]
         public void CanConstruct()
         {
-            var instance = new PropertyModel(_name, _node, _typeInfo, Substitute.For<SemanticModel>());
+            var instance = new PropertyModel(_name, _node, _typeInfo, Substitute.For<SemanticModel>(), null);
             Assert.That(instance, Is.Not.Null);
         }
 
         [Test]
         public void CannotConstructWithNullNode()
         {
-            Assert.Throws<ArgumentNullException>(() => new PropertyModel("TestValue1565919566", default(PropertyDeclarationSyntax), default(TypeInfo), Substitute.For<SemanticModel>()));
+            Assert.Throws<ArgumentNullException>(() => new PropertyModel("TestValue1565919566", default(PropertyDeclarationSyntax), default(TypeInfo), Substitute.For<SemanticModel>(), null));
         }
 
         [Test]
         public void CannotConstructWithNullSemanticModel()
         {
-            Assert.Throws<ArgumentNullException>(() => new PropertyModel("TestValue1565919566", SyntaxFactory.PropertyDeclaration(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)), "name"), default(TypeInfo), null));
+            Assert.Throws<ArgumentNullException>(() => new PropertyModel("TestValue1565919566", SyntaxFactory.PropertyDeclaration(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)), "name"), default(TypeInfo), null, null));
         }
 
         [TestCase(null)]
@@ -49,7 +49,7 @@ namespace Unitverse.Core.Tests.Models
         [TestCase("   ")]
         public void CannotConstructWithInvalidName(string value)
         {
-            Assert.Throws<ArgumentNullException>(() => new PropertyModel(value, SyntaxFactory.PropertyDeclaration(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)), "name"), default(TypeInfo), Substitute.For<SemanticModel>()));
+            Assert.Throws<ArgumentNullException>(() => new PropertyModel(value, SyntaxFactory.PropertyDeclaration(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)), "name"), default(TypeInfo), Substitute.For<SemanticModel>(), null));
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Resources/RecordType.txt
+++ b/src/Unitverse.Core.Tests/Resources/RecordType.txt
@@ -1,0 +1,4 @@
+namespace TestNamespace 
+{
+	public record RecordType(string StringProperty, int IntProperty);
+}

--- a/src/Unitverse.Core.Tests/Resources/RecordTypeWithPrimaryConstructorAndInitFields.txt
+++ b/src/Unitverse.Core.Tests/Resources/RecordTypeWithPrimaryConstructorAndInitFields.txt
@@ -1,0 +1,24 @@
+using System;
+
+namespace TestNamespace 
+{
+    record Person(string FirstName, int IntProperty)
+    {
+        private readonly string _firstName;
+        private readonly string _lastName;
+    
+        public Guid Id { get; init; }
+    
+        public string FirstName
+        {
+            get => _firstName;
+            init => _firstName = (value ?? throw new ArgumentNullException(nameof(value)));
+        }
+    
+        public string LastName
+        {
+            get => _lastName;
+            init => _lastName = (value ?? throw new ArgumentNullException(nameof(value)));
+        }
+    }
+}

--- a/src/Unitverse.Core.Tests/Resources/RecordTypeWithoutPrimaryConstructor.txt
+++ b/src/Unitverse.Core.Tests/Resources/RecordTypeWithoutPrimaryConstructor.txt
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace TestNamespace 
+{
+    record Person
+    {
+        private readonly string _firstName;
+        private readonly string _lastName;
+    
+        public Guid Id { get; init; }
+    
+        public string FirstName
+        {
+            get => _firstName;
+            init => _firstName = (value ?? throw new ArgumentNullException(nameof(value)));
+        }
+    
+        public string? MiddleName { get; init; }
+    
+        public string LastName
+        {
+            get => _lastName;
+            init => _lastName = (value ?? throw new ArgumentNullException(nameof(value)));
+        }
+
+        public IList<string> IceCreamFlavours { get; init; }
+
+        public IList<string>? Movies { get; init; }
+    }
+}

--- a/src/Unitverse.Core.Tests/TestClasses.Designer.cs
+++ b/src/Unitverse.Core.Tests/TestClasses.Designer.cs
@@ -1247,16 +1247,8 @@ namespace Unitverse.Core.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
-        /// </summary>
-        public static string ProtectedClassInternalProtected {
-            get {
-                return ResourceManager.GetString("ProtectedClassInternalProtected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to // # EmitTestsForInternals=false
+        ///   Looks up a localized string similar to // # EmitTestsForInternals=true
+        ///// # EmitSubclassForProtectedMethods=true
         ///namespace TestNamespace
         ///{
         ///    public class TestClass
@@ -1271,9 +1263,32 @@ namespace Unitverse.Core.Tests {
         ///		    System.Console.WriteLine(&quot;Testing this&quot;);
         ///	    }
         ///
-        ///	    protected internal void ThisIsAMethodProtectedInternal(string methodName, int methodValue)
+        ///	    protected internal void ThisIsAMethodProtectedInternal(string methodName, int methodVa [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string ProtectedClassInternalProtected {
+            get {
+                return ResourceManager.GetString("ProtectedClassInternalProtected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to // # EmitTestsForInternals=false
+        ///// # EmitSubclassForProtectedMethods=false
+        ///namespace TestNamespace
+        ///{
+        ///    public class TestClass
+        ///    {
+        ///	    public void ThisIsAMethod(string methodName, int methodValue)
         ///	    {
-        ///		    System.Console.WriteLi [rest of string was truncated]&quot;;.
+        ///		    System.Console.WriteLine(&quot;Testing this&quot;);
+        ///	    }
+        ///
+        ///	    protected void ThisIsAMethodProtected(string methodName, int methodValue)
+        ///	    {
+        ///		    System.Console.WriteLine(&quot;Testing this&quot;);
+        ///	    }
+        ///
+        ///	    protected internal void ThisIsAMethodProtectedInternal(string methodName, int method [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ProtectedClassNoInternalNoProtected {
             get {
@@ -1282,11 +1297,103 @@ namespace Unitverse.Core.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to // # EmitTestsForInternals=false
+        ///// # EmitSubclassForProtectedMethods=true
+        ///namespace TestNamespace
+        ///{
+        ///    public class TestClass
+        ///    {
+        ///	    public void ThisIsAMethod(string methodName, int methodValue)
+        ///	    {
+        ///		    System.Console.WriteLine(&quot;Testing this&quot;);
+        ///	    }
+        ///
+        ///	    protected void ThisIsAMethodProtected(string methodName, int methodValue)
+        ///	    {
+        ///		    System.Console.WriteLine(&quot;Testing this&quot;);
+        ///	    }
+        ///
+        ///	    protected internal void ThisIsAMethodProtectedInternal(string methodName, int methodV [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ProtectedClassNoInternalProtected {
             get {
                 return ResourceManager.GetString("ProtectedClassNoInternalProtected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to namespace TestNamespace 
+        ///{
+        ///	public record RecordType(string StringProperty, int IntProperty);
+        ///}
+        ///
+        ///namespace System.Runtime.CompilerServices
+        ///{
+        ///    internal static class IsExternalInit {}
+        ///}
+        ///.
+        /// </summary>
+        public static string RecordType {
+            get {
+                return ResourceManager.GetString("RecordType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to using System;
+        ///
+        ///namespace TestNamespace 
+        ///{
+        ///    record Person(string FirstName, int IntProperty)
+        ///    {
+        ///        private readonly string _firstName;
+        ///        private readonly string _lastName;
+        ///    
+        ///        public Guid Id { get; init; }
+        ///    
+        ///        public string FirstName
+        ///        {
+        ///            get =&gt; _firstName;
+        ///            init =&gt; _firstName = (value ?? throw new ArgumentNullException(nameof(value)));
+        ///        }
+        ///    
+        ///        public string LastName
+        ///        {
+        ///            get =&gt; _lastName;
+        ///      [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string RecordTypeWithoutPrimaryConstructor {
+            get {
+                return ResourceManager.GetString("RecordTypeWithoutPrimaryConstructor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to using System;
+        ///
+        ///namespace TestNamespace 
+        ///{
+        ///    record Person(string FirstName, int IntProperty)
+        ///    {
+        ///        private readonly string _firstName;
+        ///        private readonly string _lastName;
+        ///    
+        ///        public Guid Id { get; init; }
+        ///    
+        ///        public string FirstName
+        ///        {
+        ///            get =&gt; _firstName;
+        ///            init =&gt; _firstName = (value ?? throw new ArgumentNullException(nameof(value)));
+        ///        }
+        ///    
+        ///        public string LastName
+        ///        {
+        ///            get =&gt; _lastName;
+        ///      [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string RecordTypeWithPrimaryConstructorAndInitFields {
+            get {
+                return ResourceManager.GetString("RecordTypeWithPrimaryConstructorAndInitFields", resourceCulture);
             }
         }
         

--- a/src/Unitverse.Core.Tests/TestClasses.resx
+++ b/src/Unitverse.Core.Tests/TestClasses.resx
@@ -250,6 +250,15 @@
   <data name="ProtectedClassNoInternalProtected" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\ProtectedClassNoInternalProtected.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="RecordType" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\RecordType.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="RecordTypeWithoutPrimaryConstructor" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\RecordTypeWithoutPrimaryConstructor.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="RecordTypeWithPrimaryConstructorAndInitFields" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\RecordTypeWithPrimaryConstructorAndInitFields.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="RefAndOutParameters" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\RefAndOutParameters.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/Unitverse.Core.Tests/UnitTestGeneratorTests.cs
+++ b/src/Unitverse.Core.Tests/UnitTestGeneratorTests.cs
@@ -127,9 +127,11 @@
                 references.Add(MetadataReference.CreateFromFile(typeof(IQueryAmbient).Assembly.Location));
             }
 
+            var externalInitTree = CSharpSyntaxTree.ParseText("namespace System.Runtime.CompilerServices { internal static class IsExternalInit { } }", new CSharpParseOptions(LanguageVersion.Latest));
+
             var compilation = CSharpCompilation.Create(
                 "MyTest",
-                syntaxTrees: new[] { tree },
+                syntaxTrees: new[] { tree, externalInitTree },
                 references: references);
 
             var semanticModel = compilation.GetSemanticModel(tree);
@@ -143,7 +145,7 @@
 
             var generatedTree = CSharpSyntaxTree.ParseText(core.FileContent, new CSharpParseOptions(LanguageVersion.Latest));
 
-            var syntaxTrees = new List<SyntaxTree> { tree, generatedTree };
+            var syntaxTrees = new List<SyntaxTree> { tree, externalInitTree, generatedTree };
 
             if (core.RequiredAssets.Any(x => x == TargetAsset.PropertyTester))
             {

--- a/src/Unitverse.Core/CoreGenerator.cs
+++ b/src/Unitverse.Core/CoreGenerator.cs
@@ -12,7 +12,6 @@
     using Unitverse.Core.Helpers;
     using Unitverse.Core.Models;
     using Unitverse.Core.Options;
-    using Unitverse.Core.Resources;
     using Unitverse.Core.Strategies;
     using Unitverse.Core.Strategies.ClassDecoration;
     using Unitverse.Core.Strategies.ClassGeneration;
@@ -233,10 +232,7 @@
         {
             targetType = new ClassDecorationStrategyFactory(generationContext.FrameworkSet).Apply(targetType, generationContext.Model);
 
-            if (!generationContext.Model.IsSingleItem || generationContext.Model.Constructors.Any())
-            {
-                targetType = AddGeneratedItems(generationContext, targetType, new ClassLevelGenerationStrategyFactory(generationContext.FrameworkSet), x => new[] { x }, x => x.Constructors.Any(c => c.ShouldGenerate), (c, x) => c);
-            }
+            targetType = AddGeneratedItems(generationContext, targetType, new ClassLevelGenerationStrategyFactory(generationContext.FrameworkSet), x => new[] { x }, x => x.Constructors.Any(c => c.ShouldGenerate) || (!x.Constructors.Any() && x.Properties.Any(p => p.HasInit)), (c, x) => c);
 
             if (generationContext.Model.Interfaces.Count > 0)
             {

--- a/src/Unitverse.Core/Models/IPropertyModel.cs
+++ b/src/Unitverse.Core/Models/IPropertyModel.cs
@@ -9,6 +9,8 @@
 
         bool HasSet { get; }
 
+        bool HasInit { get; }
+
         IPropertySymbol Symbol { get; }
 
         TypeInfo TypeInfo { get; }

--- a/src/Unitverse.Core/Models/PropertyModel.cs
+++ b/src/Unitverse.Core/Models/PropertyModel.cs
@@ -9,7 +9,7 @@
 
     public class PropertyModel : TestableModel<PropertyDeclarationSyntax>, IPropertyModel
     {
-        public PropertyModel(string name, PropertyDeclarationSyntax node, TypeInfo typeInfo, SemanticModel model)
+        public PropertyModel(string name, PropertyDeclarationSyntax node, TypeInfo typeInfo, SemanticModel model, IPropertySymbol propertySymbol)
             : base(name, node)
         {
             if (model is null)
@@ -19,16 +19,26 @@
 
             TypeInfo = typeInfo;
 
-            Symbol = ModelExtensions.GetDeclaredSymbol(model, node) as IPropertySymbol;
+            Symbol = propertySymbol ?? ModelExtensions.GetDeclaredSymbol(model, node) as IPropertySymbol;
+
+            _hasGet = new Lazy<bool>(() => (Node.AccessorList?.Accessors != null && Node.AccessorList.Accessors.Any(x => x.IsKind(SyntaxKind.GetAccessorDeclaration) && !x.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword)))) || Node.ExpressionBody?.Expression != null);
+            _hasSet = new Lazy<bool>(() => Node.AccessorList?.Accessors != null && Node.AccessorList.Accessors.Any(x => x.IsKind(SyntaxKind.SetAccessorDeclaration) && !x.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword))));
+            _hasInit = new Lazy<bool>(() => Node.AccessorList?.Accessors != null && Node.AccessorList.Accessors.Any(x => x.IsKind(SyntaxKind.InitAccessorDeclaration) && !x.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword))));
         }
 
         public TypeInfo TypeInfo { get; }
 
         public IPropertySymbol Symbol { get; }
 
-        public bool HasGet => (Node.AccessorList?.Accessors != null && Node.AccessorList.Accessors.Any(x => x.IsKind(SyntaxKind.GetAccessorDeclaration) && !x.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword)))) || Node.ExpressionBody?.Expression != null;
+        private Lazy<bool> _hasGet;
+        private Lazy<bool> _hasSet;
+        private Lazy<bool> _hasInit;
 
-        public bool HasSet => Node.AccessorList?.Accessors != null && Node.AccessorList.Accessors.Any(x => x.IsKind(SyntaxKind.SetAccessorDeclaration) && !x.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword)));
+        public bool HasGet => _hasGet.Value;
+
+        public bool HasSet => _hasSet.Value;
+
+        public bool HasInit => _hasInit.Value;
 
         public bool IsStatic => Node.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword));
 

--- a/src/Unitverse.Core/Options/INamingOptions.cs
+++ b/src/Unitverse.Core/Options/INamingOptions.cs
@@ -10,6 +10,12 @@
 
         string CannotConstructWithInvalidNamingPattern { get; }
 
+        string CanInitializeNamingPattern { get; }
+
+        string CannotInitializeWithNullNamingPattern { get; }
+
+        string CannotInitializeWithInvalidNamingPattern { get; }
+
         string CanGetNamingPattern { get; }
 
         string CanSetAndGetNamingPattern { get; }

--- a/src/Unitverse.Core/Options/INamingProvider.cs
+++ b/src/Unitverse.Core/Options/INamingProvider.cs
@@ -10,6 +10,12 @@
 
         NameResolver CannotConstructWithInvalid { get; }
 
+        NameResolver CanInitialize { get; }
+
+        NameResolver CannotInitializeWithNull { get; }
+
+        NameResolver CannotInitializeWithInvalid { get; }
+
         NameResolver CanGet { get; }
 
         NameResolver CanSetAndGet { get; }

--- a/src/Unitverse.Core/Options/MutableNamingOptions.cs
+++ b/src/Unitverse.Core/Options/MutableNamingOptions.cs
@@ -15,6 +15,9 @@
             CanConstructNamingPattern = options.CanConstructNamingPattern;
             CannotConstructWithNullNamingPattern = options.CannotConstructWithNullNamingPattern;
             CannotConstructWithInvalidNamingPattern = options.CannotConstructWithInvalidNamingPattern;
+            CanInitializeNamingPattern = options.CanInitializeNamingPattern;
+            CannotInitializeWithNullNamingPattern = options.CannotInitializeWithNullNamingPattern;
+            CannotInitializeWithInvalidNamingPattern = options.CannotInitializeWithInvalidNamingPattern;
             CanGetNamingPattern = options.CanGetNamingPattern;
             CanSetAndGetNamingPattern = options.CanSetAndGetNamingPattern;
             CanSetNamingPattern = options.CanSetNamingPattern;
@@ -37,6 +40,12 @@
         public string CannotConstructWithNullNamingPattern { get; set; }
 
         public string CannotConstructWithInvalidNamingPattern { get; set; }
+
+        public string CanInitializeNamingPattern { get; set; }
+
+        public string CannotInitializeWithNullNamingPattern { get; set; }
+
+        public string CannotInitializeWithInvalidNamingPattern { get; set; }
 
         public string CanGetNamingPattern { get; set; }
 

--- a/src/Unitverse.Core/Options/NamingProvider.cs
+++ b/src/Unitverse.Core/Options/NamingProvider.cs
@@ -24,6 +24,12 @@
 
         public NameResolver CannotConstructWithInvalid => new NameResolver(_namingOptions.CannotConstructWithInvalidNamingPattern);
 
+        public NameResolver CanInitialize => new NameResolver(_namingOptions.CanInitializeNamingPattern);
+
+        public NameResolver CannotInitializeWithNull => new NameResolver(_namingOptions.CannotInitializeWithNullNamingPattern);
+
+        public NameResolver CannotInitializeWithInvalid => new NameResolver(_namingOptions.CannotInitializeWithInvalidNamingPattern);
+
         public NameResolver CanGet => new NameResolver(_namingOptions.CanGetNamingPattern);
 
         public NameResolver CanSetAndGet => new NameResolver(_namingOptions.CanSetAndGetNamingPattern);

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/ClassLevelGenerationStrategyFactory.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/ClassLevelGenerationStrategyFactory.cs
@@ -21,6 +21,9 @@
             new CanConstructMultiConstructorGenerationStrategy(_frameworkSet),
             new NullParameterCheckConstructorGenerationStrategy(_frameworkSet),
             new StringParameterCheckConstructorGenerationStrategy(_frameworkSet),
+            new CanInitializeGenerationStrategy(_frameworkSet),
+            new NullPropertyCheckInitializerGenerationStrategy(_frameworkSet),
+            new StringPropertyCheckInitializerGenerationStrategy(_frameworkSet),
         };
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullParameterCheckConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullParameterCheckConstructorGenerationStrategy.cs
@@ -36,6 +36,11 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
+            if (model.Declaration is RecordDeclarationSyntax)
+            {
+                return false;
+            }
+
             return model.Constructors.SelectMany(x => x.Parameters).Any(x => x.TypeInfo.Type.IsReferenceType && x.TypeInfo.Type.SpecialType != SpecialType.System_String) && !model.IsStatic;
         }
 
@@ -59,7 +64,7 @@
 
                 if (isNonNullable)
                 {
-                    // all params are non-nullable, so skip
+                    // all params are explicitly nullable, so skip
                     continue;
                 }
 

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullPropertyCheckInitializerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullPropertyCheckInitializerGenerationStrategy.cs
@@ -1,0 +1,84 @@
+﻿namespace Unitverse.Core.Strategies.ClassLevelGeneration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Unitverse.Core.Frameworks;
+    using Unitverse.Core.Helpers;
+    using Unitverse.Core.Models;
+    using Unitverse.Core.Options;
+
+    public class NullPropertyCheckInitializerGenerationStrategy : IGenerationStrategy<ClassModel>
+    {
+        private readonly IFrameworkSet _frameworkSet;
+
+        public NullPropertyCheckInitializerGenerationStrategy(IFrameworkSet frameworkSet)
+        {
+            _frameworkSet = frameworkSet ?? throw new ArgumentNullException(nameof(frameworkSet));
+        }
+
+        public bool IsExclusive => false;
+
+        public int Priority => 1;
+
+        public bool CanHandle(ClassModel method, ClassModel model)
+        {
+            if (method is null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            return !model.Constructors.Any() && model.Properties.Any(x => x.TypeInfo.Type.IsReferenceType && x.TypeInfo.Type.SpecialType != SpecialType.System_String && x.HasInit) && !model.IsStatic;
+        }
+
+        public IEnumerable<MethodDeclarationSyntax> Create(ClassModel method, ClassModel model, NamingContext namingContext)
+        {
+            if (method is null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            var initializableProperties = model.Properties.Where(x => x.HasInit).ToList();
+            foreach (var property in initializableProperties.Where(x => x.TypeInfo.Type.IsReferenceType && x.TypeInfo.Type.SpecialType != SpecialType.System_String))
+            {
+                if (property.Node.Type is NullableTypeSyntax)
+                {
+                    // Is explicitly nullable, so skip
+                    continue;
+                }
+
+                namingContext = namingContext.WithMemberName(property.Name, property.Name);
+
+                var generatedMethod = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CannotInitializeWithNull, namingContext, false, false);
+
+                ExpressionSyntax GetAssignedValue(IPropertyModel propertyModel)
+                {
+                    if (string.Equals(propertyModel.Name, property.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return SyntaxFactory.DefaultExpression(propertyModel.TypeInfo.ToTypeSyntax(_frameworkSet.Context));
+                    }
+
+                    return model.GetConstructorFieldReference(propertyModel, _frameworkSet);
+                }
+
+                var methodCall = Generate.ObjectCreation(model.TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetAssignedValue(x))));
+                generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+
+                yield return generatedMethod;
+            }
+        }
+    }
+}

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGenerationStrategy.cs
@@ -37,6 +37,11 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
+            if (model.Declaration is RecordDeclarationSyntax)
+            {
+                return false;
+            }
+
             return model.Constructors.SelectMany(x => x.Parameters).Any(x => x.TypeInfo.Type.IsReferenceType && x.TypeInfo.Type.SpecialType == SpecialType.System_String) && !model.IsStatic;
         }
 

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringPropertyCheckInitializerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringPropertyCheckInitializerGenerationStrategy.cs
@@ -1,0 +1,81 @@
+﻿namespace Unitverse.Core.Strategies.ClassLevelGeneration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Unitverse.Core.Frameworks;
+    using Unitverse.Core.Helpers;
+    using Unitverse.Core.Models;
+    using Unitverse.Core.Options;
+
+    public class StringPropertyCheckInitializerGenerationStrategy : IGenerationStrategy<ClassModel>
+    {
+        private readonly IFrameworkSet _frameworkSet;
+
+        public StringPropertyCheckInitializerGenerationStrategy(IFrameworkSet frameworkSet)
+        {
+            _frameworkSet = frameworkSet ?? throw new ArgumentNullException(nameof(frameworkSet));
+        }
+
+        public bool IsExclusive => false;
+
+        public int Priority => 1;
+
+        public bool CanHandle(ClassModel method, ClassModel model)
+        {
+            if (method is null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            return !model.Constructors.Any() && model.Properties.Any(x => x.TypeInfo.Type.IsReferenceType && x.TypeInfo.Type.SpecialType == SpecialType.System_String && x.HasInit) && !model.IsStatic;
+        }
+
+        public IEnumerable<MethodDeclarationSyntax> Create(ClassModel method, ClassModel model, NamingContext namingContext)
+        {
+            if (method is null)
+            {
+                throw new ArgumentNullException(nameof(method));
+            }
+
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            var initializableProperties = model.Properties.Where(x => x.HasInit).ToList();
+            foreach (var property in initializableProperties.Where(x => x.TypeInfo.Type.IsReferenceType && x.TypeInfo.Type.SpecialType == SpecialType.System_String))
+            {
+                var isNullable = property.Node.Type is NullableTypeSyntax;
+
+                namingContext = namingContext.WithMemberName(property.Name, property.Name);
+
+                object[] testValues = isNullable ? new object[] { string.Empty, "   " } : new object[] { null, string.Empty, "   " };
+                var generatedMethod = _frameworkSet.TestFramework.CreateTestCaseMethod(_frameworkSet.NamingProvider.CannotInitializeWithInvalid, namingContext, false, false, SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)), testValues);
+
+                ExpressionSyntax GetAssignedValue(IPropertyModel propertyModel)
+                {
+                    if (string.Equals(propertyModel.Name, property.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return SyntaxFactory.IdentifierName("value");
+                    }
+
+                    return model.GetConstructorFieldReference(propertyModel, _frameworkSet);
+                }
+
+                var methodCall = Generate.ObjectCreation(model.TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetAssignedValue(x))));
+                generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+
+                yield return generatedMethod;
+            }
+        }
+    }
+}

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/ReadOnlyPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/ReadOnlyPropertyGenerationStrategy.cs
@@ -37,6 +37,12 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
+            // if this is a record type without a primary constructor and this property has an init accessor
+            if (property.HasInit && !model.Constructors.Any() && !model.IsStatic)
+            {
+                return false;
+            }
+
             // readonly property without a constructor initializer parameter
             return property.HasGet && !property.HasSet && !model.Constructors.Any(x => x.Parameters.Any(p => string.Equals(p.Name, property.Name, StringComparison.OrdinalIgnoreCase)));
         }

--- a/src/Unitverse.ExampleGenerator/DefaultNamingOptions.cs
+++ b/src/Unitverse.ExampleGenerator/DefaultNamingOptions.cs
@@ -10,6 +10,12 @@
 
         public string CannotConstructWithInvalidNamingPattern { get; set; } = "CannotConstructWithInvalid{parameterName}";
 
+        public string CanInitializeNamingPattern { get; set; } = "CanInitialize";
+
+        public string CannotInitializeWithNullNamingPattern { get; set; } = "CannotInitializeWithNull{memberName}";
+
+        public string CannotInitializeWithInvalidNamingPattern { get; set; } = "CannotInitializeWithInvalid{memberName}";
+
         public string CanGetNamingPattern { get; set; } = "CanGet{memberName}";
 
         public string CanSetAndGetNamingPattern { get; set; } = "CanSetAndGet{memberName}";

--- a/src/Unitverse.ExampleGenerator/Examples.Designer.cs
+++ b/src/Unitverse.ExampleGenerator/Examples.Designer.cs
@@ -61,7 +61,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how Unitverse generates tests when the source class is abstract or contains protected methods, as well as how inheritance chains are accounted for
+        ///   Looks up a localized string similar to // ! Abstract Classes
+        ///// $ Demonstrates how Unitverse generates tests when the source class is abstract or contains protected methods, as well as how inheritance chains are accounted for
         ///
         ///using System.IO;
         ///using System.Windows;
@@ -76,9 +77,7 @@ namespace Unitverse.ExampleGenerator {
         ///
         ///        protected virtual int ProtectedMethod() =&gt; 1;
         ///
-        ///        public virtual int SomeMethod(int i) =&gt; 1;
-        ///
-        ///        public  [rest of string was truncated]&quot;;.
+        ///        public virtual int SomeMethod(int i) = [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string AbstractClass {
             get {
@@ -87,7 +86,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how tests are generated for async methods, as well as showing how the assertion framework is driven differently for async methods
+        ///   Looks up a localized string similar to // ! Async Methods
+        ///// $ Demonstrates how tests are generated for async methods, as well as showing how the assertion framework is driven differently for async methods
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -99,7 +99,7 @@ namespace Unitverse.ExampleGenerator {
         ///            return System.Threading.Tasks.Task.CompletedTask;
         ///        }
         ///
-        ///        public System.Threading.Tasks.Task&lt;int&gt; Thi [rest of string was truncated]&quot;;.
+        ///        public System.Threading [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string AsyncMethod {
             get {
@@ -108,7 +108,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how dependencies injected into constructors are tracked, and mock configuration calls emitted for any detected dependencies
+        ///   Looks up a localized string similar to // ! Automatic Mock Generation
+        ///// $ Demonstrates how dependencies injected into constructors are tracked, and mock configuration calls emitted for any detected dependencies
         ///
         ///using System.Threading.Tasks;
         ///
@@ -127,9 +128,7 @@ namespace Unitverse.ExampleGenerator {
         ///        Task&lt;string&gt; AsyncMethod(); 
         ///    }
         ///
-        ///    public interface IDummyService2
-        ///    {
-        ///        string SomeProp [rest of string was truncated]&quot;;.
+        ///    public interface IDummyService2 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string AutomaticMockGeneration {
             get {
@@ -138,7 +137,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how appropriate types are selected for the generation of tests for generic types with type constraints
+        ///   Looks up a localized string similar to // ! Constrained Generic Types
+        ///// $ Demonstrates how appropriate types are selected for the generation of tests for generic types with type constraints
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -158,8 +158,7 @@ namespace Unitverse.ExampleGenerator {
         ///    }
         ///
         ///    public class TestBoth : ITest, ITest2
-        ///    {
-        ///        public int ThisIsAP [rest of string was truncated]&quot;;.
+        ///   [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ConstrainedGenericType {
             get {
@@ -168,7 +167,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how Unitverse generates default values for method parameters when the parameter is a delegate type
+        ///   Looks up a localized string similar to // ! Delegate Generation
+        ///// $ Demonstrates how Unitverse generates default values for method parameters when the parameter is a delegate type
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -190,7 +190,7 @@ namespace Unitverse.ExampleGenerator {
         ///        {
         ///        }
         ///
-        ///        public static void ThisIsAMethod2(Func&lt;stri [rest of string was truncated]&quot;;.
+        ///        public static voi [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DelegateGeneration {
             get {
@@ -199,7 +199,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how Unitverse generates tests for extension methods
+        ///   Looks up a localized string similar to // ! Extension Methods
+        ///// $ Demonstrates how Unitverse generates tests for extension methods
         ///
         ///using System;
         ///using System.Drawing;
@@ -219,7 +220,7 @@ namespace Unitverse.ExampleGenerator {
         ///            return source;
         ///        }
         ///
-        ///        public static T ToOther&lt;T&gt;(this List&lt;T [rest of string was truncated]&quot;;.
+        ///        public static  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ExtensionMethod {
             get {
@@ -228,7 +229,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework. Also shows using FluentAssertions for the assertion framework.
+        ///   Looks up a localized string similar to // ! Frameworks - Fluent Assertions
+        ///// $ Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework. Also shows using FluentAssertions for the assertion framework.
         ///// # FrameworkType=XUnit
         ///// # MockingFrameworkType=NSubstitute
         ///// # UseFluentAssertions=true
@@ -243,9 +245,7 @@ namespace Unitverse.ExampleGenerator {
         ///    public class TestClass
         ///    {
         ///        public TestClass(IDependency dependency)
-        ///        { }
-        ///
-        ///        public void Som [rest of string was truncated]&quot;;.
+        ///  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string FrameworksFluentAssertions {
             get {
@@ -254,7 +254,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework
+        ///   Looks up a localized string similar to // ! Frameworks - MSTest &amp; Moq
+        ///// $ Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework
         ///// # FrameworkType=MSTest
         ///// # MockingFrameworkType=Moq
         ///// # UseFluentAssertions=false
@@ -272,8 +273,7 @@ namespace Unitverse.ExampleGenerator {
         ///        { }
         ///
         ///        public void SomeMethod(string methodName, int methodValue)
-        ///        {
-        ///            System.Co [rest of string was truncated]&quot;;.
+        /// [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string FrameworksMsTestMoq {
             get {
@@ -282,7 +282,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how tests are generated using NUnit 3 for the test framework and FakeItEasy for the mocking framework
+        ///   Looks up a localized string similar to // ! Frameworks - NUnit 3 &amp; FakeItEasy
+        ///// $ Demonstrates how tests are generated using NUnit 3 for the test framework and FakeItEasy for the mocking framework
         ///// # FrameworkType=NUnit3
         ///// # MockingFrameworkType=FakeItEasy
         ///// # UseFluentAssertions=false
@@ -299,9 +300,7 @@ namespace Unitverse.ExampleGenerator {
         ///        public TestClass(IDependency dependency)
         ///        { }
         ///
-        ///        public void SomeMethod(string methodName, int methodValue)
-        ///        {
-        ///       [rest of string was truncated]&quot;;.
+        ///        public void SomeMethod(string methodN [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string FrameworksNUnitFakeItEasy {
             get {
@@ -310,7 +309,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework
+        ///   Looks up a localized string similar to // ! Frameworks - XUnit &amp; NSubstitute
+        ///// $ Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework
         ///// # FrameworkType=XUnit
         ///// # MockingFrameworkType=NSubstitute
         ///// # UseFluentAssertions=false
@@ -327,9 +327,7 @@ namespace Unitverse.ExampleGenerator {
         ///        public TestClass(IDependency dependency)
         ///        { }
         ///
-        ///        public void SomeMethod(string methodName, int methodValue)
-        ///        {
-        ///        [rest of string was truncated]&quot;;.
+        ///        public void SomeMethod(string methodNam [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string FrameworksXUnitNSubstitute {
             get {
@@ -338,7 +336,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how Unitverse generates tests for generic methods
+        ///   Looks up a localized string similar to // ! Generic Methods
+        ///// $ Demonstrates how Unitverse generates tests for generic methods
         ///
         ///using System;
         ///
@@ -360,7 +359,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates the tests generated for a type that implements IComparable
+        ///   Looks up a localized string similar to // ! IComparable
+        ///// $ Demonstrates the tests generated for a type that implements IComparable
         ///
         ///using System;
         ///
@@ -378,8 +378,7 @@ namespace Unitverse.ExampleGenerator {
         ///        public int CompareTo(TestComparableGeneric obj)
         ///        {
         ///            if (obj == null)
-        ///            {
-        ///                 [rest of string was truncated]&quot;;.
+        ///            { [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string IComparableTests {
             get {
@@ -388,7 +387,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates the tests generated for a type that contains an indexer
+        ///   Looks up a localized string similar to // ! Indexers
+        ///// $ Demonstrates the tests generated for a type that contains an indexer
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -414,7 +414,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Shows how unitverse generates a test to verify mappings between input parameter type and return type where the types share property names
+        ///   Looks up a localized string similar to // ! Mapping Methods
+        ///// $ Shows how unitverse generates a test to verify mappings between input parameter type and return type where the types share property names
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -428,7 +429,7 @@ namespace Unitverse.ExampleGenerator {
         ///    public class OutputClass
         ///    {
         ///        public string SomeProperty { get; set; }
-        ///        public string SomeOtherProperty { get; [rest of string was truncated]&quot;;.
+        ///        public string So [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string MappingMethod {
             get {
@@ -437,7 +438,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Shows how unitverse generates unambiguous names for methods that test multiple overloads of the same source method
+        ///   Looks up a localized string similar to // ! Multiple Overloads
+        ///// $ Shows how unitverse generates unambiguous names for methods that test multiple overloads of the same source method
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -456,8 +458,7 @@ namespace Unitverse.ExampleGenerator {
         ///    public static class FluentFactory
         ///    {
         ///        public static Tuple&lt;Stage, IList&lt;Stage&gt;&gt; Follows(this Stage stage, params Stage[] followedStages)
-        ///        {
-        ///		    return nu [rest of string was truncated]&quot;;.
+        ///  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string MultipleOverloads {
             get {
@@ -466,7 +467,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Shows how Unitverse will omit `null` tests for parameters declared to explicitly accept null
+        ///   Looks up a localized string similar to // ! Nullable Reference Types
+        ///// $ Shows how Unitverse will omit `null` tests for parameters declared to explicitly accept null
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -486,7 +488,7 @@ namespace Unitverse.ExampleGenerator {
         ///        {
         ///        }
         /// 
-        ///        public string GetFullName(string first, string? middle, string [rest of string was truncated]&quot;;.
+        ///        public string GetFullName(strin [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string NullableReferenceTypes {
             get {
@@ -495,7 +497,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Shows how Unitverse emits tests for declared unary and binary operators
+        ///   Looks up a localized string similar to // ! Operator Overloading
+        ///// $ Shows how Unitverse emits tests for declared unary and binary operators
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -513,8 +516,7 @@ namespace Unitverse.ExampleGenerator {
         ///        public static Calculator operator + (Calculator Calc1, Calculator Calc2) 
         ///        { 
         ///            Calculator Calc3 = new Calculator(0); 
-        ///            Calc3.number = Calc2.number + Calc1.number; 
-        ///            [rest of string was truncated]&quot;;.
+        ///            Calc3.number = Calc2.number +  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string OperatorOverloading {
             get {
@@ -523,7 +525,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how test values are produced to initialize POCO members when the type is consumed
+        ///   Looks up a localized string similar to // ! POCO Initialization
+        ///// $ Demonstrates how test values are produced to initialize POCO members when the type is consumed
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -545,7 +548,7 @@ namespace Unitverse.ExampleGenerator {
         ///			_poco = poco;
         ///        }
         /// 
-        ///        public SomePoco Poc [rest of string was truncated]&quot;;.
+        ///  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string PocoInitialization {
             get {
@@ -554,7 +557,50 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates the tests that Unitverse emits when methods contain `ref` or `out` parameters
+        ///   Looks up a localized string similar to // ! Record Types (init Properties)
+        ///// $ Demonstrates the tests generated for a record type that has properties that have init accessors
+        ///
+        ///using System;
+        ///using System.Collections.Generic;
+        ///
+        ///namespace TestNamespace 
+        ///{
+        ///    record Person
+        ///    {
+        ///        private readonly string _firstName;
+        ///        private readonly string _lastName;
+        ///    
+        ///        public Guid Id { get; init; }
+        ///    
+        ///        public string FirstName
+        ///        {
+        ///            get =&gt; _firstName;
+        ///            init =&gt; _firstName = (value ?? throw [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string RecordTypeInitProperties {
+            get {
+                return ResourceManager.GetString("RecordTypeInitProperties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to // ! Record Types (Primary Constructor)
+        ///// $ Demonstrates the tests generated for a simple primary constructor record type
+        ///
+        ///namespace TestNamespace 
+        ///{
+        ///	public record RecordType(string StringProperty, int IntProperty);
+        ///}.
+        /// </summary>
+        internal static string RecordTypesPrimaryConstructor {
+            get {
+                return ResourceManager.GetString("RecordTypesPrimaryConstructor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to // ! ref &amp; out Parameters
+        ///// $ Demonstrates the tests that Unitverse emits when methods contain `ref` or `out` parameters
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -570,10 +616,7 @@ namespace Unitverse.ExampleGenerator {
         ///            outParam = &quot;&quot;;
         ///        }
         ///
-        ///        public void RefParamMethodClass(string stringProp, ref TestClass refParam)
-        ///        {
-        ///
-        ///      [rest of string was truncated]&quot;;.
+        ///        public void RefParamMethodClass(string stringProp, ref TestClass re [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string RefAndOutParameters {
             get {
@@ -582,7 +625,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how tests are generated for a simple POCO type
+        ///   Looks up a localized string similar to // ! Simple POCO
+        ///// $ Demonstrates how tests are generated for a simple POCO type
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -603,7 +647,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how Unitverse attempts to use a static property to get a type instance when the constructor is private
+        ///   Looks up a localized string similar to // ! Singletons
+        ///// $ Demonstrates how Unitverse attempts to use a static property to get a type instance when the constructor is private
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -624,8 +669,7 @@ namespace Unitverse.ExampleGenerator {
         ///
         ///        public bool IsShared =&gt; true;
         ///
-        ///        public string GetTableName(string baseName)
-        ///       [rest of string was truncated]&quot;;.
+        ///        public string GetTableName(string  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Singleton {
             get {
@@ -634,7 +678,8 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to // $ Demonstrates how Unitverse generates tests when the source class is static
+        ///   Looks up a localized string similar to // ! Static Classes
+        ///// $ Demonstrates how Unitverse generates tests when the source class is static
         ///
         ///namespace Unitverse.Examples
         ///{
@@ -652,7 +697,7 @@ namespace Unitverse.ExampleGenerator {
         ///            return &quot;Hello&quot;;
         ///        }
         ///
-        ///        public static int ThisIsAProperty { get; se [rest of string was truncated]&quot;;.
+        ///        public static int This [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string StaticClass {
             get {

--- a/src/Unitverse.ExampleGenerator/Examples.resx
+++ b/src/Unitverse.ExampleGenerator/Examples.resx
@@ -172,6 +172,12 @@
   <data name="PocoInitialization" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\PocoInitialization.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="RecordTypeInitProperties" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\RecordTypeInitProperties.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="RecordTypesPrimaryConstructor" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\RecordTypesPrimaryConstructor.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="RefAndOutParameters" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\RefAndOutParameters.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/Unitverse.ExampleGenerator/Resources/AbstractClass.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/AbstractClass.txt
@@ -1,3 +1,4 @@
+// ! Abstract Classes
 // $ Demonstrates how Unitverse generates tests when the source class is abstract or contains protected methods, as well as how inheritance chains are accounted for
 
 using System.IO;

--- a/src/Unitverse.ExampleGenerator/Resources/AsyncMethod.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/AsyncMethod.txt
@@ -1,3 +1,4 @@
+// ! Async Methods
 // $ Demonstrates how tests are generated for async methods, as well as showing how the assertion framework is driven differently for async methods
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/AutomaticMockGeneration.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/AutomaticMockGeneration.txt
@@ -1,3 +1,4 @@
+// ! Automatic Mock Generation
 // $ Demonstrates how dependencies injected into constructors are tracked, and mock configuration calls emitted for any detected dependencies
 
 using System.Threading.Tasks;

--- a/src/Unitverse.ExampleGenerator/Resources/ConstrainedGenericType.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/ConstrainedGenericType.txt
@@ -1,3 +1,4 @@
+// ! Constrained Generic Types
 // $ Demonstrates how appropriate types are selected for the generation of tests for generic types with type constraints
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/DelegateGeneration.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/DelegateGeneration.txt
@@ -1,3 +1,4 @@
+// ! Delegate Generation
 // $ Demonstrates how Unitverse generates default values for method parameters when the parameter is a delegate type
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/ExtensionMethod.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/ExtensionMethod.txt
@@ -1,3 +1,4 @@
+// ! Extension Methods
 // $ Demonstrates how Unitverse generates tests for extension methods
 
 using System;

--- a/src/Unitverse.ExampleGenerator/Resources/FrameworksFluentAssertions.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/FrameworksFluentAssertions.txt
@@ -1,3 +1,4 @@
+// ! Frameworks - Fluent Assertions
 // $ Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework. Also shows using FluentAssertions for the assertion framework.
 // # FrameworkType=XUnit
 // # MockingFrameworkType=NSubstitute

--- a/src/Unitverse.ExampleGenerator/Resources/FrameworksMsTestMoq.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/FrameworksMsTestMoq.txt
@@ -1,3 +1,4 @@
+// ! Frameworks - MSTest & Moq
 // $ Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework
 // # FrameworkType=MSTest
 // # MockingFrameworkType=Moq

--- a/src/Unitverse.ExampleGenerator/Resources/FrameworksNUnitFakeItEasy.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/FrameworksNUnitFakeItEasy.txt
@@ -1,3 +1,4 @@
+// ! Frameworks - NUnit 3 & FakeItEasy
 // $ Demonstrates how tests are generated using NUnit 3 for the test framework and FakeItEasy for the mocking framework
 // # FrameworkType=NUnit3
 // # MockingFrameworkType=FakeItEasy

--- a/src/Unitverse.ExampleGenerator/Resources/FrameworksXUnitNSubstitute.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/FrameworksXUnitNSubstitute.txt
@@ -1,3 +1,4 @@
+// ! Frameworks - XUnit & NSubstitute
 // $ Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework
 // # FrameworkType=XUnit
 // # MockingFrameworkType=NSubstitute

--- a/src/Unitverse.ExampleGenerator/Resources/GenericMethod.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/GenericMethod.txt
@@ -1,3 +1,4 @@
+// ! Generic Methods
 // $ Demonstrates how Unitverse generates tests for generic methods
 
 using System;

--- a/src/Unitverse.ExampleGenerator/Resources/IComparableTests.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/IComparableTests.txt
@@ -1,3 +1,4 @@
+// ! IComparable
 // $ Demonstrates the tests generated for a type that implements IComparable
 
 using System;

--- a/src/Unitverse.ExampleGenerator/Resources/IndexerTests.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/IndexerTests.txt
@@ -1,3 +1,4 @@
+// ! Indexers
 // $ Demonstrates the tests generated for a type that contains an indexer
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/MappingMethod.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/MappingMethod.txt
@@ -1,3 +1,4 @@
+// ! Mapping Methods
 // $ Shows how unitverse generates a test to verify mappings between input parameter type and return type where the types share property names
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/MultipleOverloads.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/MultipleOverloads.txt
@@ -1,3 +1,4 @@
+// ! Multiple Overloads
 // $ Shows how unitverse generates unambiguous names for methods that test multiple overloads of the same source method
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/NullableReferenceTypes.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/NullableReferenceTypes.txt
@@ -1,3 +1,4 @@
+// ! Nullable Reference Types
 // $ Shows how Unitverse will omit `null` tests for parameters declared to explicitly accept null
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/OperatorOverloading.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/OperatorOverloading.txt
@@ -1,3 +1,4 @@
+// ! Operator Overloading
 // $ Shows how Unitverse emits tests for declared unary and binary operators
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/PocoInitialization.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/PocoInitialization.txt
@@ -1,3 +1,4 @@
+// ! POCO Initialization
 // $ Demonstrates how test values are produced to initialize POCO members when the type is consumed
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/RecordTypeInitProperties.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/RecordTypeInitProperties.txt
@@ -1,0 +1,32 @@
+// ! Record Types (init Properties)
+// $ Demonstrates the tests generated for a record type that has properties that have init accessors
+
+using System;
+using System.Collections.Generic;
+
+namespace TestNamespace 
+{
+    record Person
+    {
+        private readonly string _firstName;
+        private readonly string _lastName;
+    
+        public Guid Id { get; init; }
+    
+        public string FirstName
+        {
+            get => _firstName;
+            init => _firstName = (value ?? throw new ArgumentNullException(nameof(value)));
+        }
+    
+        public string? MiddleName { get; init; }
+    
+        public string LastName
+        {
+            get => _lastName;
+            init => _lastName = (value ?? throw new ArgumentNullException(nameof(value)));
+        }
+
+        public IList<string> IceCreamFlavours { get; init; }
+    }
+}

--- a/src/Unitverse.ExampleGenerator/Resources/RecordTypesPrimaryConstructor.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/RecordTypesPrimaryConstructor.txt
@@ -1,0 +1,7 @@
+// ! Record Types (Primary Constructor)
+// $ Demonstrates the tests generated for a simple primary constructor record type
+
+namespace TestNamespace 
+{
+	public record RecordType(string StringProperty, int IntProperty);
+}

--- a/src/Unitverse.ExampleGenerator/Resources/RefAndOutParameters.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/RefAndOutParameters.txt
@@ -1,3 +1,4 @@
+// ! ref & out Parameters
 // $ Demonstrates the tests that Unitverse emits when methods contain `ref` or `out` parameters
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/SimplePoco.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/SimplePoco.txt
@@ -1,3 +1,4 @@
+// ! Simple POCO
 // $ Demonstrates how tests are generated for a simple POCO type
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/Singleton.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/Singleton.txt
@@ -1,3 +1,4 @@
+// ! Singletons
 // $ Demonstrates how Unitverse attempts to use a static property to get a type instance when the constructor is private
 
 namespace Unitverse.Examples

--- a/src/Unitverse.ExampleGenerator/Resources/StaticClass.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/StaticClass.txt
@@ -1,3 +1,4 @@
+// ! Static Classes
 // $ Demonstrates how Unitverse generates tests when the source class is static
 
 namespace Unitverse.Examples

--- a/src/Unitverse.Specs/DefaultNamingOptions.cs
+++ b/src/Unitverse.Specs/DefaultNamingOptions.cs
@@ -10,6 +10,12 @@
 
         public string CannotConstructWithInvalidNamingPattern { get; set; } = "CannotConstructWithInvalid{parameterName}";
 
+        public string CanInitializeNamingPattern { get; set; } = "CanInitialize";
+
+        public string CannotInitializeWithNullNamingPattern { get; set; } = "CannotInitializeWithNull{memberName}";
+
+        public string CannotInitializeWithInvalidNamingPattern { get; set; } = "CannotInitializeWithInvalid{memberName}";
+
         public string CanGetNamingPattern { get; set; } = "CanGet{memberName}";
 
         public string CanSetAndGetNamingPattern { get; set; } = "CanSetAndGet{memberName}";

--- a/src/Unitverse/Options/NamingOptions.cs
+++ b/src/Unitverse/Options/NamingOptions.cs
@@ -22,6 +22,21 @@ namespace Unitverse.Options
         [Description("Naming format for the constructor test that checks string null or white space guards")]
         public string CannotConstructWithInvalidNamingPattern { get; set; } = "CannotConstructWithInvalid{parameterName}";
 
+        [Category("Initializers")]
+        [DisplayName("CanInitialize")]
+        [Description("Naming format for the main initializer test")]
+        public string CanInitializeNamingPattern { get; set; } = "CanInitialize";
+
+        [Category("Initializers")]
+        [DisplayName("CannotInitializeWithNull")]
+        [Description("Naming format for the initializer test that checks null guards")]
+        public string CannotInitializeWithNullNamingPattern { get; set; } = "CannotInitializeWithNull{memberName}";
+
+        [Category("Initializers")]
+        [DisplayName("CannotInitializeWithInvalid")]
+        [Description("Naming format for the initializer test that checks string null or white space guards")]
+        public string CannotInitializeWithInvalidNamingPattern { get; set; } = "CannotInitializeWithInvalid{memberName}";
+
         [Category("Properties && Indexers")]
         [DisplayName("CanGet")]
         [Description("Naming format for read-only property tests")]


### PR DESCRIPTION
Addresses #35 

Adds support for record types with primary constructors, init properties or a mix
Also modifies the way that examples are generated so that the titles are nicer