### PR TITLE
Support for turning off groups of strategies

### DIFF
--- a/src/Unitverse.Core.Tests/DefaultStrategyOptions.cs
+++ b/src/Unitverse.Core.Tests/DefaultStrategyOptions.cs
@@ -1,0 +1,33 @@
+﻿namespace Unitverse.Core.Tests
+{
+    using Unitverse.Core.Options;
+
+    public class DefaultStrategyOptions : IStrategyOptions
+    {
+        public bool ConstructorChecksAreEnabled => true;
+
+        public bool InitializerChecksAreEnabled => true;
+
+        public bool ConstructorParameterChecksAreEnabled => true;
+
+        public bool InitializerPropertyChecksAreEnabled => true;
+
+        public bool MethodCallChecksAreEnabled => true;
+
+        public bool MappingMethodChecksAreEnabled => true;
+
+        public bool MethodParameterChecksAreEnabled => true;
+
+        public bool IndexerChecksAreEnabled => true;
+
+        public bool PropertyChecksAreEnabled => true;
+
+        public bool InitializedPropertyChecksAreEnabled => true;
+
+        public bool OperatorChecksAreEnabled => true;
+
+        public bool OperatorParameterChecksAreEnabled => true;
+
+        public bool InterfaceImplementationChecksAreEnabled => true;
+    }
+}

--- a/src/Unitverse.Core.Tests/Helpers/AssignmentValueHelperTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/AssignmentValueHelperTests.cs
@@ -50,7 +50,7 @@ namespace Unitverse.Core.Tests.Helpers
             generationOptions.FrameworkType.Returns(TestFrameworkTypes.NUnit3);
             generationOptions.MockingFrameworkType.Returns(MockingFrameworkType.NSubstitute);
             generationOptions.TestTypeNaming.Returns("{0}Tests");
-            var options = new UnitTestGeneratorOptions(generationOptions, Substitute.For<INamingOptions>(), false);
+            var options = new UnitTestGeneratorOptions(generationOptions, Substitute.For<INamingOptions>(), new DefaultStrategyOptions(), false);
             var frameworkSet = FrameworkSetFactory.Create(options);
 
             var visitedTypes = new HashSet<string>();

--- a/src/Unitverse.Core.Tests/Options/UnitTestGeneratorOptionsFactoryTests.cs
+++ b/src/Unitverse.Core.Tests/Options/UnitTestGeneratorOptionsFactoryTests.cs
@@ -12,13 +12,19 @@ namespace Unitverse.Core.Tests.Options
         [Test]
         public static void CannotCallCreateWithNullGenerationOptions()
         {
-            Assert.Throws<ArgumentNullException>(() => UnitTestGeneratorOptionsFactory.Create("TestValue1494081794", default(IGenerationOptions), Substitute.For<INamingOptions>(), false));
+            Assert.Throws<ArgumentNullException>(() => UnitTestGeneratorOptionsFactory.Create("TestValue1494081794", default(IGenerationOptions), Substitute.For<INamingOptions>(), Substitute.For<IStrategyOptions>(), false));
         }
 
         [Test]
         public static void CannotCallCreateWithNullNamingOptions()
         {
-            Assert.Throws<ArgumentNullException>(() => UnitTestGeneratorOptionsFactory.Create("TestValue1494081794", Substitute.For<IGenerationOptions>(), default(INamingOptions), false));
+            Assert.Throws<ArgumentNullException>(() => UnitTestGeneratorOptionsFactory.Create("TestValue1494081794", Substitute.For<IGenerationOptions>(), default(INamingOptions), Substitute.For<IStrategyOptions>(), false));
+        }
+
+        [Test]
+        public static void CannotCallCreateWithNullStrategyOptions()
+        {
+            Assert.Throws<ArgumentNullException>(() => UnitTestGeneratorOptionsFactory.Create("TestValue1494081794", Substitute.For<IGenerationOptions>(), Substitute.For<INamingOptions>(), default(IStrategyOptions), false));
         }
 
         [TestCase(null)]
@@ -26,7 +32,7 @@ namespace Unitverse.Core.Tests.Options
         [TestCase("   ")]
         public static void CanCallCreateWithInvalidSolutionFilePath(string value)
         {
-            Assert.DoesNotThrow(() => UnitTestGeneratorOptionsFactory.Create(value, Substitute.For<IGenerationOptions>(), Substitute.For<INamingOptions>(), false));
+            Assert.DoesNotThrow(() => UnitTestGeneratorOptionsFactory.Create(value, Substitute.For<IGenerationOptions>(), Substitute.For<INamingOptions>(), Substitute.For<IStrategyOptions>(), false));
         }
 
         [Test]
@@ -56,13 +62,14 @@ namespace Unitverse.Core.Tests.Options
                 var solutionFilePath = Path.Combine(pathC, "someSolution.sln");
                 var generationOptions = Substitute.For<IGenerationOptions>();
                 var namingOptions = Substitute.For<INamingOptions>();
+                var strategyOptions = Substitute.For<IStrategyOptions>();
                 generationOptions.MockingFrameworkType.Returns(MockingFrameworkType.NSubstitute);
 
                 File.WriteAllText(Path.Combine(pathA, CoreConstants.ConfigFileName), "framework-type=XUnit");
                 File.WriteAllText(Path.Combine(pathB, CoreConstants.ConfigFileName), "framework-type=NUnit3");
                 File.WriteAllText(Path.Combine(pathC, CoreConstants.ConfigFileName), "framework-type=NUnit2");
 
-                var result = UnitTestGeneratorOptionsFactory.Create(solutionFilePath, generationOptions, namingOptions, false);
+                var result = UnitTestGeneratorOptionsFactory.Create(solutionFilePath, generationOptions, namingOptions, strategyOptions, false);
                 Assert.That(result.GenerationOptions.FrameworkType, Is.EqualTo(TestFrameworkTypes.NUnit2));
                 Assert.That(result.GenerationOptions.MockingFrameworkType, Is.EqualTo(MockingFrameworkType.NSubstitute));
             }

--- a/src/Unitverse.Core.Tests/Options/UnitTestGeneratorOptionsTests.cs
+++ b/src/Unitverse.Core.Tests/Options/UnitTestGeneratorOptionsTests.cs
@@ -12,6 +12,7 @@ namespace Unitverse.Core.Tests.Options
         private UnitTestGeneratorOptions _testClass;
         private IGenerationOptions _generationOptions;
         private INamingOptions _namingOptions;
+        private IStrategyOptions _strategyOptions;
         private bool _statisticsCollectionEnabled;
 
         [SetUp]
@@ -19,27 +20,34 @@ namespace Unitverse.Core.Tests.Options
         {
             _generationOptions = Substitute.For<IGenerationOptions>();
             _namingOptions = Substitute.For<INamingOptions>();
+            _strategyOptions = Substitute.For<IStrategyOptions>();
             _statisticsCollectionEnabled = true;
-            _testClass = new UnitTestGeneratorOptions(_generationOptions, _namingOptions, _statisticsCollectionEnabled);
+            _testClass = new UnitTestGeneratorOptions(_generationOptions, _namingOptions, _strategyOptions, _statisticsCollectionEnabled);
         }
 
         [Test]
         public void CanConstruct()
         {
-            var instance = new UnitTestGeneratorOptions(_generationOptions, _namingOptions, _statisticsCollectionEnabled);
+            var instance = new UnitTestGeneratorOptions(_generationOptions, _namingOptions, _strategyOptions, _statisticsCollectionEnabled);
             instance.Should().NotBeNull();
         }
 
         [Test]
         public void CannotConstructWithNullGenerationOptions()
         {
-            FluentActions.Invoking(() => new UnitTestGeneratorOptions(default(IGenerationOptions), Substitute.For<INamingOptions>(), true)).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new UnitTestGeneratorOptions(default(IGenerationOptions), Substitute.For<INamingOptions>(), Substitute.For<IStrategyOptions>(), true)).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void CannotConstructWithNullNamingOptions()
         {
-            FluentActions.Invoking(() => new UnitTestGeneratorOptions(Substitute.For<IGenerationOptions>(), default(INamingOptions), true)).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new UnitTestGeneratorOptions(Substitute.For<IGenerationOptions>(), default(INamingOptions), Substitute.For<IStrategyOptions>(), true)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CannotConstructWithNullStrategyOptions()
+        {
+            FluentActions.Invoking(() => new UnitTestGeneratorOptions(Substitute.For<IGenerationOptions>(), Substitute.For<INamingOptions>(), default(IStrategyOptions), true)).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
@@ -52,6 +60,12 @@ namespace Unitverse.Core.Tests.Options
         public void NamingOptionsIsInitializedCorrectly()
         {
             _testClass.NamingOptions.Should().BeSameAs(_namingOptions);
+        }
+
+        [Test]
+        public void StrategyOptionsIsInitializedCorrectly()
+        {
+            _testClass.StrategyOptions.Should().BeSameAs(_strategyOptions);
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Resources/ExcludedStrategies.txt
+++ b/src/Unitverse.Core.Tests/Resources/ExcludedStrategies.txt
@@ -1,0 +1,52 @@
+// # ConstructorChecksAreEnabled=false
+// # ConstructorParameterChecksAreEnabled=false
+// # MethodParameterChecksAreEnabled=false
+// # PropertyChecksAreEnabled=false
+
+namespace TestNamespace.SubNameSpace
+{
+
+    public interface ITest
+    {
+        int ThisIsAProperty {get;set;}
+    }
+
+    public class TestClass
+    {
+        public TestClass(string stringProp, ITest iTest)
+        {
+
+        }
+ 
+        public TestClass(int? nullableIntProp, ITest iTest)
+        {
+
+        }
+ 
+        public TestClass(int thisIsAProperty, ITest iTest)
+        {
+
+        }
+ 
+	    public void ThisIsAMethod(string methodName, int methodValue)
+	    {
+		    System.Console.WriteLine("Testing this");
+	    }
+
+        public string WillReturnAString()
+        {
+            return "Hello";
+        }
+
+        private string _thisIsAString = string.Empty;
+        public string ThisIsAWriteOnlyString { set { _thisIsAString = value; }}
+
+        public int ThisIsAProperty { get;set;}
+
+        protected int ProtectedProperty { get;set;}
+
+        public ITest GetITest { get; }
+
+        public TestClass ThisClass {get;set;}
+    }
+}

--- a/src/Unitverse.Core.Tests/Strategies/ValueGeneration/ValueGenerationStrategyFactoryTester.cs
+++ b/src/Unitverse.Core.Tests/Strategies/ValueGeneration/ValueGenerationStrategyFactoryTester.cs
@@ -61,7 +61,7 @@ namespace Unitverse.Core.Tests.Strategies.ValueGeneration
             generationOptions.FrameworkType.Returns(TestFrameworkTypes.NUnit3);
             generationOptions.MockingFrameworkType.Returns(MockingFrameworkType.NSubstitute);
             generationOptions.TestTypeNaming.Returns("{0}Tests");
-            var options = new UnitTestGeneratorOptions(generationOptions, Substitute.For<INamingOptions>(), false);
+            var options = new UnitTestGeneratorOptions(generationOptions, Substitute.For<INamingOptions>(), new DefaultStrategyOptions(), false);
             var frameworkSet = FrameworkSetFactory.Create(options);
             var expression = ValueGenerationStrategyFactory.GenerateFor(info, model, new HashSet<string>(StringComparer.OrdinalIgnoreCase),  frameworkSet);
 

--- a/src/Unitverse.Core.Tests/TestClasses.Designer.cs
+++ b/src/Unitverse.Core.Tests/TestClasses.Designer.cs
@@ -660,6 +660,40 @@ namespace Unitverse.Core.Tests {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to // # ConstructorChecksAreEnabled=false
+        ///// # ConstructorParameterChecksAreEnabled=false
+        ///// # MethodParameterChecksAreEnabled=false
+        ///// # PropertyChecksAreEnabled=false
+        ///
+        ///namespace TestNamespace.SubNameSpace
+        ///{
+        ///
+        ///    public interface ITest
+        ///    {
+        ///        int ThisIsAProperty {get;set;}
+        ///    }
+        ///
+        ///    public class TestClass
+        ///    {
+        ///        public TestClass(string stringProp, ITest iTest)
+        ///        {
+        ///
+        ///        }
+        /// 
+        ///        public TestClass(int? nullableIntProp, ITest iTest)
+        ///        {
+        ///
+        ///        }
+        /// 
+        ///      [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string ExcludedStrategies {
+            get {
+                return ResourceManager.GetString("ExcludedStrategies", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 
         ///using System;
         ///using System.Drawing;

--- a/src/Unitverse.Core.Tests/TestClasses.resx
+++ b/src/Unitverse.Core.Tests/TestClasses.resx
@@ -181,6 +181,9 @@
   <data name="DependencyObjectTestFile" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\DependencyObjectTestFile.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="ExcludedStrategies" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\ExcludedStrategies.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="ExtensionMethod" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\ExtensionMethod.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/Unitverse.Core.Tests/UnitTestGeneratorTests.cs
+++ b/src/Unitverse.Core.Tests/UnitTestGeneratorTests.cs
@@ -70,12 +70,13 @@
 
             var generationOptions = new MutableGenerationOptions(new DefaultGenerationOptions());
             var namingOptions = new MutableNamingOptions(new DefaultNamingOptions());
+            var strategyOptions = new MutableStrategyOptions(new DefaultStrategyOptions());
 
             generationOptions.FrameworkType = testFrameworkTypes;
             generationOptions.MockingFrameworkType = mockingFrameworkType;
             generationOptions.UseFluentAssertions = useFluentAssertions;
 
-            var options = new UnitTestGeneratorOptions(generationOptions, namingOptions, false);
+            var options = new UnitTestGeneratorOptions(generationOptions, namingOptions, strategyOptions, false);
 
             var lines = classAsText.Lines().Where(x => x.StartsWith("// #", StringComparison.Ordinal)).Select(x => x.Substring(4).Trim()).ToList();
             if (lines.Any())
@@ -92,6 +93,7 @@
 
                 properties.ApplyTo(generationOptions);
                 properties.ApplyTo(namingOptions);
+                properties.ApplyTo(strategyOptions);
             }
 
             var tree = CSharpSyntaxTree.ParseText(classAsText, new CSharpParseOptions(LanguageVersion.Latest));

--- a/src/Unitverse.Core/CoreGenerator.cs
+++ b/src/Unitverse.Core/CoreGenerator.cs
@@ -73,7 +73,7 @@
                 if (shouldGenerate(member))
                 {
                     namingContext = nameDecorator(namingContext, member);
-                    foreach (var method in factory.CreateFor(member, generationContext.Model, namingContext))
+                    foreach (var method in factory.CreateFor(member, generationContext.Model, namingContext, generationContext.FrameworkSet.Options.StrategyOptions))
                     {
                         var methodName = method.Identifier.Text;
                         var existingMethod = declaration.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault(x => string.Equals(x.Identifier.Text, methodName, StringComparison.OrdinalIgnoreCase));

--- a/src/Unitverse.Core/Options/IStrategyOptions.cs
+++ b/src/Unitverse.Core/Options/IStrategyOptions.cs
@@ -1,0 +1,31 @@
+﻿namespace Unitverse.Core.Options
+{
+    public interface IStrategyOptions
+    {
+        bool ConstructorChecksAreEnabled { get; }
+
+        bool InitializerChecksAreEnabled { get; }
+
+        bool ConstructorParameterChecksAreEnabled { get; }
+
+        bool InitializerPropertyChecksAreEnabled { get; }
+
+        bool MethodCallChecksAreEnabled { get; }
+
+        bool MappingMethodChecksAreEnabled { get; }
+
+        bool MethodParameterChecksAreEnabled { get; }
+
+        bool IndexerChecksAreEnabled { get; }
+
+        bool PropertyChecksAreEnabled { get; }
+
+        bool InitializedPropertyChecksAreEnabled { get; }
+
+        bool OperatorChecksAreEnabled { get; }
+
+        bool OperatorParameterChecksAreEnabled { get; }
+
+        bool InterfaceImplementationChecksAreEnabled { get; }
+    }
+}

--- a/src/Unitverse.Core/Options/IUnitTestGeneratorOptions.cs
+++ b/src/Unitverse.Core/Options/IUnitTestGeneratorOptions.cs
@@ -7,5 +7,7 @@
         IGenerationOptions GenerationOptions { get; }
 
         INamingOptions NamingOptions { get; }
+
+        IStrategyOptions StrategyOptions { get; }
     }
 }

--- a/src/Unitverse.Core/Options/MutableStrategyOptions.cs
+++ b/src/Unitverse.Core/Options/MutableStrategyOptions.cs
@@ -1,0 +1,55 @@
+﻿namespace Unitverse.Core.Options
+{
+    using System;
+
+    public class MutableStrategyOptions : IStrategyOptions
+    {
+        public MutableStrategyOptions(IStrategyOptions options)
+        {
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            ConstructorChecksAreEnabled = options.ConstructorChecksAreEnabled;
+            InitializerChecksAreEnabled = options.InitializerChecksAreEnabled;
+            ConstructorParameterChecksAreEnabled = options.ConstructorParameterChecksAreEnabled;
+            InitializerPropertyChecksAreEnabled = options.InitializerPropertyChecksAreEnabled;
+            MethodCallChecksAreEnabled = options.MethodCallChecksAreEnabled;
+            MappingMethodChecksAreEnabled = options.MappingMethodChecksAreEnabled;
+            MethodParameterChecksAreEnabled = options.MethodParameterChecksAreEnabled;
+            IndexerChecksAreEnabled = options.IndexerChecksAreEnabled;
+            PropertyChecksAreEnabled = options.PropertyChecksAreEnabled;
+            InitializedPropertyChecksAreEnabled = options.InitializedPropertyChecksAreEnabled;
+            OperatorChecksAreEnabled = options.OperatorChecksAreEnabled;
+            OperatorParameterChecksAreEnabled = options.OperatorParameterChecksAreEnabled;
+            InterfaceImplementationChecksAreEnabled = options.InterfaceImplementationChecksAreEnabled;
+        }
+
+        public bool ConstructorChecksAreEnabled { get; set; }
+
+        public bool InitializerChecksAreEnabled { get; set; }
+
+        public bool ConstructorParameterChecksAreEnabled { get; set; }
+
+        public bool InitializerPropertyChecksAreEnabled { get; set; }
+
+        public bool MethodCallChecksAreEnabled { get; set; }
+
+        public bool MappingMethodChecksAreEnabled { get; set; }
+
+        public bool MethodParameterChecksAreEnabled { get; set; }
+
+        public bool IndexerChecksAreEnabled { get; set; }
+
+        public bool PropertyChecksAreEnabled { get; set; }
+
+        public bool InitializedPropertyChecksAreEnabled { get; set; }
+
+        public bool OperatorChecksAreEnabled { get; set; }
+
+        public bool OperatorParameterChecksAreEnabled { get; set; }
+
+        public bool InterfaceImplementationChecksAreEnabled { get; set; }
+    }
+}

--- a/src/Unitverse.Core/Options/UnitTestGeneratorOptions.cs
+++ b/src/Unitverse.Core/Options/UnitTestGeneratorOptions.cs
@@ -4,16 +4,19 @@
 
     public class UnitTestGeneratorOptions : IUnitTestGeneratorOptions
     {
-        public UnitTestGeneratorOptions(IGenerationOptions generationOptions, INamingOptions namingOptions, bool statisticsCollectionEnabled)
+        public UnitTestGeneratorOptions(IGenerationOptions generationOptions, INamingOptions namingOptions, IStrategyOptions strategyOptions, bool statisticsCollectionEnabled)
         {
             GenerationOptions = generationOptions ?? throw new ArgumentNullException(nameof(generationOptions));
             NamingOptions = namingOptions ?? throw new ArgumentNullException(nameof(namingOptions));
+            StrategyOptions = strategyOptions ?? throw new ArgumentNullException(nameof(strategyOptions));
             StatisticsCollectionEnabled = statisticsCollectionEnabled;
         }
 
         public IGenerationOptions GenerationOptions { get; }
 
         public INamingOptions NamingOptions { get; }
+
+        public IStrategyOptions StrategyOptions { get; }
 
         public bool StatisticsCollectionEnabled { get; }
     }

--- a/src/Unitverse.Core/Options/UnitTestGeneratorOptionsFactory.cs
+++ b/src/Unitverse.Core/Options/UnitTestGeneratorOptionsFactory.cs
@@ -7,7 +7,7 @@
 
     public static class UnitTestGeneratorOptionsFactory
     {
-        public static IUnitTestGeneratorOptions Create(string solutionFilePath, IGenerationOptions generationOptions, INamingOptions namingOptions, bool statisticsGenerationEnabled)
+        public static IUnitTestGeneratorOptions Create(string solutionFilePath, IGenerationOptions generationOptions, INamingOptions namingOptions, IStrategyOptions strategyOptions, bool statisticsGenerationEnabled)
         {
             if (generationOptions == null)
             {
@@ -16,6 +16,7 @@
 
             var mutableGenerationOptions = new MutableGenerationOptions(generationOptions);
             var mutableNamingOptions = new MutableNamingOptions(namingOptions);
+            var mutableStrategyOptions = new MutableStrategyOptions(strategyOptions);
 
             if (!string.IsNullOrWhiteSpace(solutionFilePath))
             {
@@ -29,9 +30,10 @@
 
                 properties.ApplyTo(mutableGenerationOptions);
                 properties.ApplyTo(mutableNamingOptions);
+                properties.ApplyTo(mutableStrategyOptions);
             }
 
-            return new UnitTestGeneratorOptions(mutableGenerationOptions, mutableNamingOptions, statisticsGenerationEnabled);
+            return new UnitTestGeneratorOptions(mutableGenerationOptions, mutableNamingOptions, mutableStrategyOptions, statisticsGenerationEnabled);
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructMultiConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructMultiConstructorGenerationStrategy.cs
@@ -25,6 +25,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.ConstructorChecksAreEnabled;
+
         public bool CanHandle(ClassModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructNoConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructNoConstructorGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.ConstructorChecksAreEnabled;
+
         public bool CanHandle(ClassModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructSingleConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructSingleConstructorGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.ConstructorChecksAreEnabled;
+
         public bool CanHandle(ClassModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanInitializeGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanInitializeGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.InitializerChecksAreEnabled;
+
         public bool CanHandle(ClassModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullParameterCheckConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullParameterCheckConstructorGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.ConstructorParameterChecksAreEnabled;
+
         public bool CanHandle(ClassModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullPropertyCheckInitializerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullPropertyCheckInitializerGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.InitializerPropertyChecksAreEnabled;
+
         public bool CanHandle(ClassModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGenerationStrategy.cs
@@ -25,6 +25,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.ConstructorParameterChecksAreEnabled;
+
         public bool CanHandle(ClassModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringPropertyCheckInitializerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringPropertyCheckInitializerGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.InitializerPropertyChecksAreEnabled;
+
         public bool CanHandle(ClassModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/IGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/IGenerationStrategy.cs
@@ -1,5 +1,6 @@
 ﻿namespace Unitverse.Core.Strategies
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Unitverse.Core.Models;
@@ -10,6 +11,8 @@
         bool IsExclusive { get; }
 
         int Priority { get; }
+
+        Func<IStrategyOptions, bool> IsEnabled { get; }
 
         bool CanHandle(T member, ClassModel model);
 

--- a/src/Unitverse.Core/Strategies/IndexerGeneration/ReadOnlyIndexerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/IndexerGeneration/ReadOnlyIndexerGenerationStrategy.cs
@@ -23,6 +23,8 @@
 
         public int Priority => 2;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.IndexerChecksAreEnabled;
+
         public bool CanHandle(IIndexerModel indexer, ClassModel model)
         {
             if (indexer == null)

--- a/src/Unitverse.Core/Strategies/IndexerGeneration/ReadWriteIndexerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/IndexerGeneration/ReadWriteIndexerGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.IndexerChecksAreEnabled;
+
         public bool CanHandle(IIndexerModel property, ClassModel model)
         {
             if (property == null)

--- a/src/Unitverse.Core/Strategies/IndexerGeneration/WriteOnlyIndexerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/IndexerGeneration/WriteOnlyIndexerGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 2;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.IndexerChecksAreEnabled;
+
         public bool CanHandle(IIndexerModel indexer, ClassModel model)
         {
             if (indexer == null)

--- a/src/Unitverse.Core/Strategies/InterfaceGeneration/InterfaceGenerationStrategyBase.cs
+++ b/src/Unitverse.Core/Strategies/InterfaceGeneration/InterfaceGenerationStrategyBase.cs
@@ -30,6 +30,8 @@
 
         protected abstract NameResolver GeneratedMethodNamePattern { get; }
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.InterfaceImplementationChecksAreEnabled;
+
         public virtual bool CanHandle(ClassModel classModel, ClassModel model)
         {
             if (classModel == null)

--- a/src/Unitverse.Core/Strategies/ItemGenerationStrategyFactory.cs
+++ b/src/Unitverse.Core/Strategies/ItemGenerationStrategyFactory.cs
@@ -10,11 +10,16 @@
     {
         protected abstract IEnumerable<IGenerationStrategy<T>> Strategies { get; }
 
-        public IEnumerable<MethodDeclarationSyntax> CreateFor(T item, ClassModel model, NamingContext namingContext)
+        public IEnumerable<MethodDeclarationSyntax> CreateFor(T item, ClassModel model, NamingContext namingContext, IStrategyOptions strategyOptions)
         {
             var strategies = Strategies.Where(x => x.CanHandle(item, model)).OrderByDescending(x => x.Priority);
             foreach (var strategy in strategies)
             {
+                if (!strategy.IsEnabled(strategyOptions))
+                {
+                    continue;
+                }
+
                 foreach (var method in strategy.Create(item, model, namingContext))
                 {
                     yield return method;

--- a/src/Unitverse.Core/Strategies/MethodGeneration/CanCallMethodGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/MethodGeneration/CanCallMethodGenerationStrategy.cs
@@ -25,6 +25,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.MethodCallChecksAreEnabled;
+
         public bool CanHandle(IMethodModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/MethodGeneration/MappingMethodGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/MethodGeneration/MappingMethodGenerationStrategy.cs
@@ -26,6 +26,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.MappingMethodChecksAreEnabled;
+
         public bool CanHandle(IMethodModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/MethodGeneration/NullParameterCheckMethodGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/MethodGeneration/NullParameterCheckMethodGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.MethodParameterChecksAreEnabled;
+
         public bool CanHandle(IMethodModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/MethodGeneration/StringParameterCheckMethodGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/MethodGeneration/StringParameterCheckMethodGenerationStrategy.cs
@@ -25,6 +25,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.MethodParameterChecksAreEnabled;
+
         public bool CanHandle(IMethodModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/OperatorGeneration/CanCallOperatorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/OperatorGeneration/CanCallOperatorGenerationStrategy.cs
@@ -23,6 +23,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.OperatorChecksAreEnabled;
+
         public bool CanHandle(IOperatorModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/OperatorGeneration/NullParameterCheckOperatorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/OperatorGeneration/NullParameterCheckOperatorGenerationStrategy.cs
@@ -25,6 +25,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.OperatorParameterChecksAreEnabled;
+
         public bool CanHandle(IOperatorModel method, ClassModel model)
         {
             if (method is null)

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/MultiConstructorInitializedPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/MultiConstructorInitializedPropertyGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 3;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.InitializedPropertyChecksAreEnabled;
+
         public bool CanHandle(IPropertyModel property, ClassModel model)
         {
             if (property is null)

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/NotifyPropertyChangedGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/NotifyPropertyChangedGenerationStrategy.cs
@@ -26,6 +26,8 @@
 
         public int Priority => 2;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.PropertyChecksAreEnabled;
+
         public bool CanHandle(IPropertyModel property, ClassModel model)
         {
             if (property == null)

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/ReadOnlyPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/ReadOnlyPropertyGenerationStrategy.cs
@@ -25,6 +25,8 @@
 
         public int Priority => 2;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.PropertyChecksAreEnabled;
+
         public bool CanHandle(IPropertyModel property, ClassModel model)
         {
             if (property == null)

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/ReadWritePropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/ReadWritePropertyGenerationStrategy.cs
@@ -25,6 +25,8 @@
 
         public int Priority => 1;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.PropertyChecksAreEnabled;
+
         public bool CanHandle(IPropertyModel property, ClassModel model)
         {
             if (property == null)

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/SingleConstructorInitializedPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/SingleConstructorInitializedPropertyGenerationStrategy.cs
@@ -23,6 +23,8 @@
 
         public int Priority => 3;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.InitializedPropertyChecksAreEnabled;
+
         public bool CanHandle(IPropertyModel property, ClassModel model)
         {
             if (property is null)

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/WriteOnlyPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/WriteOnlyPropertyGenerationStrategy.cs
@@ -24,6 +24,8 @@
 
         public int Priority => 2;
 
+        public Func<IStrategyOptions, bool> IsEnabled => x => x.PropertyChecksAreEnabled;
+
         public bool CanHandle(IPropertyModel property, ClassModel model)
         {
             if (property == null)

--- a/src/Unitverse.ExampleGenerator/DefaultStrategyOptions.cs
+++ b/src/Unitverse.ExampleGenerator/DefaultStrategyOptions.cs
@@ -1,0 +1,33 @@
+﻿namespace Unitverse.ExampleGenerator
+{
+    using Unitverse.Core.Options;
+
+    public class DefaultStrategyOptions : IStrategyOptions
+    {
+        public bool ConstructorChecksAreEnabled => true;
+
+        public bool InitializerChecksAreEnabled => true;
+
+        public bool ConstructorParameterChecksAreEnabled => true;
+
+        public bool InitializerPropertyChecksAreEnabled => true;
+
+        public bool MethodCallChecksAreEnabled => true;
+
+        public bool MappingMethodChecksAreEnabled => true;
+
+        public bool MethodParameterChecksAreEnabled => true;
+
+        public bool IndexerChecksAreEnabled => true;
+
+        public bool PropertyChecksAreEnabled => true;
+
+        public bool InitializedPropertyChecksAreEnabled => true;
+
+        public bool OperatorChecksAreEnabled => true;
+
+        public bool OperatorParameterChecksAreEnabled => true;
+
+        public bool InterfaceImplementationChecksAreEnabled => true;
+    }
+}

--- a/src/Unitverse.ExampleGenerator/Program.cs
+++ b/src/Unitverse.ExampleGenerator/Program.cs
@@ -105,8 +105,9 @@ namespace Unitverse.ExampleGenerator
         {
             var generationOptions = new MutableGenerationOptions(new DefaultGenerationOptions());
             var namingOptions = new MutableNamingOptions(new DefaultNamingOptions());
+            var strategyOptions = new MutableStrategyOptions(new DefaultStrategyOptions());
 
-            var options = new UnitTestGeneratorOptions(generationOptions, namingOptions, false);
+            var options = new UnitTestGeneratorOptions(generationOptions, namingOptions, strategyOptions, false);
 
             var lines = classAsText.Lines().Where(x => x.StartsWith("// #", StringComparison.Ordinal)).Select(x => x.Substring(4).Trim()).ToList();
             if (lines.Any())

--- a/src/Unitverse.Specs/BaseSteps.cs
+++ b/src/Unitverse.Specs/BaseSteps.cs
@@ -26,7 +26,7 @@
             _context.SemanticModel = model;
 
             var extractor = new TestableItemExtractor(syntaxTree, model);
-            _context.ClassModel = extractor.Extract(syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First(), new UnitTestGeneratorOptions(new GenerationOptions(TestFrameworkTypes.NUnit3, MockingFrameworkType.NSubstitute), new DefaultNamingOptions(), false)).First();
+            _context.ClassModel = extractor.Extract(syntaxTree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First(), new UnitTestGeneratorOptions(new GenerationOptions(TestFrameworkTypes.NUnit3, MockingFrameworkType.NSubstitute), new DefaultNamingOptions(), new DefaultStrategyOptions(), false)).First();
         }
 
         [Given(@"I set my test framework to '(.*)'")]

--- a/src/Unitverse.Specs/ClassBasedStrategySteps.cs
+++ b/src/Unitverse.Specs/ClassBasedStrategySteps.cs
@@ -38,7 +38,7 @@
         [When(@"I generate tests for the class using strategy '(.*)'")]
         public void WhenIGenerateTestsForTheClass(string strategy)
         {
-            var options = new UnitTestGeneratorOptions(new GenerationOptions(_context.TargetFramework, _context.MockFramework), new DefaultNamingOptions(), false);
+            var options = GenerationOptions.Get(_context.TargetFramework, _context.MockFramework);
             var frameworkSet = FrameworkSetFactory.Create(options);
 
             IClassGenerationStrategy generationStrategy = null;
@@ -85,7 +85,7 @@
         [When(@"I regenerate tests for all constructors")]
         public async Task WhenIRegenerateTests()
         {
-            var options = new UnitTestGeneratorOptions(new GenerationOptions(_context.TargetFramework, _context.MockFramework), new DefaultNamingOptions(), false);
+            var options = GenerationOptions.Get(_context.TargetFramework, _context.MockFramework);
             var result = await CoreGenerator.Generate(_context.SemanticModel, _context.ClassModel.Constructors.First().Node, _context.TestModel, true, options, x => x + ".Tests", false, new NullMessageLogger());
             var tree = CSharpSyntaxTree.ParseText(result.FileContent, new CSharpParseOptions(LanguageVersion.Latest));
 

--- a/src/Unitverse.Specs/DefaultStrategyOptions.cs
+++ b/src/Unitverse.Specs/DefaultStrategyOptions.cs
@@ -1,0 +1,33 @@
+﻿namespace Unitverse.Specs
+{
+    using Unitverse.Core.Options;
+
+    public class DefaultStrategyOptions : IStrategyOptions
+    {
+        public bool ConstructorChecksAreEnabled => true;
+
+        public bool InitializerChecksAreEnabled => true;
+
+        public bool ConstructorParameterChecksAreEnabled => true;
+
+        public bool InitializerPropertyChecksAreEnabled => true;
+
+        public bool MethodCallChecksAreEnabled => true;
+
+        public bool MappingMethodChecksAreEnabled => true;
+
+        public bool MethodParameterChecksAreEnabled => true;
+
+        public bool IndexerChecksAreEnabled => true;
+
+        public bool PropertyChecksAreEnabled => true;
+
+        public bool InitializedPropertyChecksAreEnabled => true;
+
+        public bool OperatorChecksAreEnabled => true;
+
+        public bool OperatorParameterChecksAreEnabled => true;
+
+        public bool InterfaceImplementationChecksAreEnabled => true;
+    }
+}

--- a/src/Unitverse.Specs/GenerationOptions.cs
+++ b/src/Unitverse.Specs/GenerationOptions.cs
@@ -11,6 +11,11 @@
             MockingFrameworkType = mockFramework;
         }
 
+        public static IUnitTestGeneratorOptions Get(TestFrameworkTypes testFramework, MockingFrameworkType mockFramework)
+        {
+            return new UnitTestGeneratorOptions(new GenerationOptions(testFramework, mockFramework), new DefaultNamingOptions(), new DefaultStrategyOptions(), false);
+        }
+
         public TestFrameworkTypes FrameworkType { get; }
         public MockingFrameworkType MockingFrameworkType { get; }
         public bool CreateProjectAutomatically { get; } = true;

--- a/src/Unitverse.Specs/MethodBasedStrategySteps.cs
+++ b/src/Unitverse.Specs/MethodBasedStrategySteps.cs
@@ -31,7 +31,7 @@
         [When(@"I generate unit tests for the class using strategy '(.*)'")]
         public void WhenIGenerateUnitTestsForTheClass(string strategy)
         {
-            var options = new UnitTestGeneratorOptions(new GenerationOptions(_context.TargetFramework, _context.MockFramework), new DefaultNamingOptions(), false);
+            var options = GenerationOptions.Get(_context.TargetFramework, _context.MockFramework);
             var frameworkSet = FrameworkSetFactory.Create(options);
 
             // ENHANCE - Replace with an Argument Transformation: https://specflow.org/documentation/Step-Argument-Transformations/
@@ -87,7 +87,7 @@
         [When(@"I generate tests for the method using the strategy '(.*)'")]
         public void WhenIGenerateTestsForTheMethod(string strategy)
         {
-            var options = new UnitTestGeneratorOptions(new GenerationOptions(_context.TargetFramework, _context.MockFramework), new DefaultNamingOptions(), false);
+            var options = GenerationOptions.Get(_context.TargetFramework, _context.MockFramework);
             var frameworkSet = FrameworkSetFactory.Create(options);
 
             IGenerationStrategy<IMethodModel> generationStrategy = null;
@@ -124,7 +124,7 @@
         [When(@"I generate tests for the indexer using the strategy '(.*)'")]
         public void WhenIGenerateTestsForTheIndexer(string strategy)
         {
-            var options = new UnitTestGeneratorOptions(new GenerationOptions(_context.TargetFramework, _context.MockFramework), new DefaultNamingOptions(), false);
+            var options = GenerationOptions.Get(_context.TargetFramework, _context.MockFramework);
             var frameworkSet = FrameworkSetFactory.Create(options);
 
             IGenerationStrategy<IIndexerModel> generationStrategy = null;
@@ -156,7 +156,7 @@
         [When(@"I generate tests for the operator using the strategy '(.*)'")]
         public void WhenIGenerateTestsForTheOperator(string strategy)
         {
-            var options = new UnitTestGeneratorOptions(new GenerationOptions(_context.TargetFramework, _context.MockFramework), new DefaultNamingOptions(), false);
+            var options = GenerationOptions.Get(_context.TargetFramework, _context.MockFramework);
             var frameworkSet = FrameworkSetFactory.Create(options);
 
             IGenerationStrategy<IOperatorModel> generationStrategy = null;
@@ -183,7 +183,7 @@
         [When(@"I generate tests for the property using the strategy '(.*)'")]
         public void WhenIGenerateTestsForTheProperty(string strategy)
         {
-            var options = new UnitTestGeneratorOptions(new GenerationOptions(_context.TargetFramework, _context.MockFramework), new DefaultNamingOptions(), false);
+            var options = GenerationOptions.Get(_context.TargetFramework, _context.MockFramework);
             var frameworkSet = FrameworkSetFactory.Create(options);
 
             IGenerationStrategy<IPropertyModel> generationStrategy = null;

--- a/src/Unitverse/Commands/GenerateTestForSymbolCommand.cs
+++ b/src/Unitverse/Commands/GenerateTestForSymbolCommand.cs
@@ -223,7 +223,7 @@
                 }
 
                 var generationOptions = OptionsResolver.DetectFrameworks(targetProject, options.GenerationOptions);
-                var resolvedOptions = new UnitTestGeneratorOptions(generationOptions, options.NamingOptions, options.StatisticsCollectionEnabled);
+                var resolvedOptions = new UnitTestGeneratorOptions(generationOptions, options.NamingOptions, options.StrategyOptions, options.StatisticsCollectionEnabled);
 
                 var projectMappings = new List<ProjectMapping>();
                 var set = new HashSet<TargetAsset>();

--- a/src/Unitverse/Commands/GenerateUnitTestsCommand.cs
+++ b/src/Unitverse/Commands/GenerateUnitTestsCommand.cs
@@ -149,7 +149,7 @@
                     {
                         var generationOptions = OptionsResolver.DetectFrameworks(targetProject, options.GenerationOptions);
 
-                        projectMappings[source.Project] = new ProjectMapping(source.Project, targetProject, new UnitTestGeneratorOptions(generationOptions, options.NamingOptions, options.StatisticsCollectionEnabled));
+                        projectMappings[source.Project] = new ProjectMapping(source.Project, targetProject, new UnitTestGeneratorOptions(generationOptions, options.NamingOptions, options.StrategyOptions, options.StatisticsCollectionEnabled));
                     }
                 }
 

--- a/src/Unitverse/IUnitTestGeneratorPackage.cs
+++ b/src/Unitverse/IUnitTestGeneratorPackage.cs
@@ -16,6 +16,8 @@
 
         INamingOptions NamingOptions { get; }
 
+        IStrategyOptions StrategyOptions { get; }
+
         VisualStudioWorkspace Workspace { get; }
 
         Task<object> GetServiceAsync(Type serviceType);

--- a/src/Unitverse/Options/ExportOptionsControl.cs
+++ b/src/Unitverse/Options/ExportOptionsControl.cs
@@ -42,7 +42,7 @@ namespace Unitverse.Options
                                 }
                             }
 
-                            ConfigExporter.WriteTo(targetPath, new object[] { unitTestGeneratorPackage.GenerationOptions, unitTestGeneratorPackage.NamingOptions });
+                            ConfigExporter.WriteTo(targetPath, new object[] { unitTestGeneratorPackage.GenerationOptions, unitTestGeneratorPackage.NamingOptions, unitTestGeneratorPackage.StrategyOptions });
 
                             MessageBox.Show(this, "Options written to: " + targetPath, "Unitverse", MessageBoxButtons.OK, MessageBoxIcon.Information);
                         }

--- a/src/Unitverse/Options/StrategyOptions.cs
+++ b/src/Unitverse/Options/StrategyOptions.cs
@@ -1,0 +1,75 @@
+﻿// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global - is set by VS
+namespace Unitverse.Options
+{
+    using System.ComponentModel;
+    using Microsoft.VisualStudio.Shell;
+    using Unitverse.Core.Options;
+
+    internal class StrategyOptions : DialogPage, IStrategyOptions
+    {
+        [Category("Constructors")]
+        [DisplayName("Basic Checks")]
+        [Description("Whether to emit basic constructor checks (CanConstruct)")]
+        public bool ConstructorChecksAreEnabled { get; set; } = true;
+
+        [Category("Constructors")]
+        [DisplayName("Parameter Checks")]
+        [Description("Whether to emit null and string parameter checks for constructors (CannotConstructWith*)")]
+        public bool ConstructorParameterChecksAreEnabled { get; set; } = true;
+
+        [Category("Initializers")]
+        [DisplayName("Basic Checks")]
+        [Description("Whether to emit basic constructor checks (CanInitialize)")]
+        public bool InitializerChecksAreEnabled { get; set; } = true;
+
+        [Category("Initializers")]
+        [DisplayName("Parameter Checks")]
+        [Description("Whether to emit null and string parameter checks for initializers (CannotInitializeWith*)")]
+        public bool InitializerPropertyChecksAreEnabled { get; set; } = true;
+
+        [Category("Methods")]
+        [DisplayName("Basic Checks")]
+        [Description("Whether to emit tests that exercise methods (CanCall*)")]
+        public bool MethodCallChecksAreEnabled { get; set; } = true;
+
+        [Category("Methods")]
+        [DisplayName("Mapping Method Checks")]
+        [Description("Whether to emit tests that check mapping methods (*PerformsMapping)")]
+        public bool MappingMethodChecksAreEnabled { get; set; } = true;
+
+        [Category("Methods")]
+        [DisplayName("Parameter Checks")]
+        [Description("Whether to emit null and string parameter checks for methods (CannotCallWith*)")]
+        public bool MethodParameterChecksAreEnabled { get; set; } = true;
+
+        [Category("Indexers")]
+        [DisplayName("Basic Checks")]
+        [Description("Whether to emit tests to exercise indexers (CanGet/Set*)")]
+        public bool IndexerChecksAreEnabled { get; set; } = true;
+
+        [Category("Properties")]
+        [DisplayName("Basic Checks")]
+        [Description("Whether to emit tests to exercise properties (CanGet/Set*)")]
+        public bool PropertyChecksAreEnabled { get; set; } = true;
+
+        [Category("Properties")]
+        [DisplayName("Initialized Property Checks")]
+        [Description("Whether to emit tests that check that properties have been initialized based on constructor parameter names (*IsInitializedCorrectly)")]
+        public bool InitializedPropertyChecksAreEnabled { get; set; } = true;
+
+        [Category("Operators")]
+        [DisplayName("Basic Checks")]
+        [Description("Whether to emit tests to exercise properties (CanGet/Set*)")]
+        public bool OperatorChecksAreEnabled { get; set; } = true;
+
+        [Category("Operators")]
+        [DisplayName("Parameter Checks")]
+        [Description("Whether to emit null and string parameter checks for initializers (CannotCallOperatorWith*)")]
+        public bool OperatorParameterChecksAreEnabled { get; set; } = true;
+
+        [Category("Interfaces")]
+        [DisplayName("Implementation Checks")]
+        [Description("Whether to emit checks that verify interface implementation (Implements*)")]
+        public bool InterfaceImplementationChecksAreEnabled { get; set; } = true;
+    }
+}

--- a/src/Unitverse/UnitTestGeneratorPackage.cs
+++ b/src/Unitverse/UnitTestGeneratorPackage.cs
@@ -20,6 +20,7 @@
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideOptionPage(typeof(GenerationOptions), "Unitverse", "Generation Options", 0, 0, true)]
     [ProvideOptionPage(typeof(NamingOptions), "Unitverse", "Naming Options", 0, 0, true)]
+    [ProvideOptionPage(typeof(StrategyOptions), "Unitverse", "Strategy Options", 0, 0, true)]
     [ProvideOptionPage(typeof(ExportOptions), "Unitverse", "Options Export", 0, 0, true)]
     [ProvideOptionPage(typeof(StatisticsOptions), "Unitverse", "Statistics", 0, 0, true)]
     public sealed class UnitTestGeneratorPackage : AsyncPackage, IUnitTestGeneratorPackage
@@ -28,13 +29,15 @@
 
         public INamingOptions NamingOptions => (NamingOptions)GetDialogPage(typeof(NamingOptions));
 
+        public IStrategyOptions StrategyOptions => (StrategyOptions)GetDialogPage(typeof(StrategyOptions));
+
         public IUnitTestGeneratorOptions Options
         {
             get
             {
                 var solutionFilePath = Workspace?.CurrentSolution?.FilePath;
                 var statisticsOptions = (StatisticsOptions)GetDialogPage(typeof(StatisticsOptions));
-                return UnitTestGeneratorOptionsFactory.Create(solutionFilePath, GenerationOptions, NamingOptions, statisticsOptions.Enabled);
+                return UnitTestGeneratorOptionsFactory.Create(solutionFilePath, GenerationOptions, NamingOptions, StrategyOptions, statisticsOptions.Enabled);
             }
         }
 

--- a/src/Unitverse/Unitverse.csproj
+++ b/src/Unitverse/Unitverse.csproj
@@ -114,6 +114,9 @@
     <Compile Include="Options\StatisticsOptionsControl.Designer.cs">
       <DependentUpon>StatisticsOptionsControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="Options\StrategyOptions.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Strings.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Adds the ability to disable groups of strategies from emitting tests. Addresses #42

Known issue: If you turn off tests that require a derived class to be emitted (i.e. you have a protected property, you have the option enabled to emit a derived class, but you turn off property tests) then a derived class will still be emitted. Opened #46 to address that, because it's relatively complex so deserves it's own item.