### PR TITLE
Section comments

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,2 @@
 title: Unitverse
-theme: jekyll-theme-minimal
+theme: jekyll-theme-cayman

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ You can configure Unitverse in two ways:
 * By changing the options in Visual Studio by going to Tools->Options->Unitverse.
 * By settings the options in a `.unitTestGeneratorConfig` file which works just like a `.editorConfig` file.
 
-You can create a `.unitTestGeneratorConfig` file which contains the options you currently have configured in Visual Studio by going to the 'Export' options page.
+You can create a `.unitTestGeneratorConfig` file which contains the options you currently have configured in Visual Studio by going to the 'Export' options page. For more information on this, see the 'Setting options per-solution' section below.
 
 ## Generation Options
 
@@ -14,8 +14,32 @@ You can create a `.unitTestGeneratorConfig` file which contains the options you 
 * Control preferences around using placement, generation without projects & partial generation
 * Control whether mock configuration calls are automatically emitted
 * Control whether tests for internal members are emitted
+* Control whether to emit a derived test class to expose protected members
+* Control whether Arrange / Act / Assert comments are emitted and what they say
 
-_Note: The default for project naming is **‘{0}.Tests’**. For example, a project named **MyProject** would be associated with a test project called **MyProject.Tests**. The default for the class and file naming is **‘{0}Tests’**. For example, a class called **MyClass** would be associated with a test class called **MyClassTests** and a file called a class called **MyClass.cs** would be associated with a test class called **MyClassTests.cs**._
+### Default Project/Class/File Naming
+
+The default for project naming is `{0}.Tests`. For example, a project named `MyProject` would be associated with a test project called `MyProject.Tests`. The default for the class and file naming is `{0}Tests`. For example, a class called `MyClass` would be associated with a test class called `MyClassTests` and a file called a class called `MyClass.cs` would be associated with a test class called `MyClassTests.cs`.
+
+## Strategy Options
+
+Unitverse generates tests using 'strategies'. There are strategies for testing constructors & parameters, properties, methods & parameters etc. Not all tests are useful for every code base. One example would be that null checks are less useful in a codebase making use of nullable reference types. In this instance, you may want to turn off 'Constructors - Parameter Checks' and 'Methods - Parameter Checks'. The groups that you can disable are listed in the table below. All groups are enabled by default.
+
+| Category | Group | Meaning |
+| - | - | - |
+| Constructors | Basic Checks | Whether to emit basic constructor checks (CanConstruct) |
+| Constructors | Parameter Checks | Whether to emit null and string parameter checks for constructors (CannotConstructWith*) |
+| Initializers | Basic Checks | Whether to emit basic constructor checks (CanInitialize) |
+| Initializers | Parameter Checks | Whether to emit null and string parameter checks for initializers (CannotInitializeWith*) |
+| Methods | Basic Checks | Whether to emit tests that exercise methods (CanCall*) |
+| Methods | Mapping Method Checks | Whether to emit tests that check mapping methods (*PerformsMapping) |
+| Methods | Parameter Checks | Whether to emit null and string parameter checks for methods (CannotCallWith*) |
+| Indexers | Basic Checks | Whether to emit tests to exercise indexers (CanGet/Set*) |
+| Properties | Basic Checks | Whether to emit tests to exercise properties (CanGet/Set*) |
+| Properties | Initialized Property Checks | Whether to emit tests that check that properties have been initialized based on constructor parameter names (*IsInitializedCorrectly) |
+| Operators | Basic Checks | Whether to emit tests to exercise operators (CanCallOperator) |
+| Operators | Parameter Checks | Whether to emit null and string parameter checks for operators (CannotCallOperatorWith*) |
+| Interfaces | Implementation Checks | Whether to emit checks that verify interface implementation (Implements*) |
 
 ## Test Method Naming Options
 
@@ -61,4 +85,4 @@ MockingFrameworkType=NSubstitute
 
 To generate a `.unitTestGeneratorConfig` file that contains all the options as they are set in the Visual Studio Options dialogue, you can go to the 'Options Export' configuration page which contains the functionality allowing you to export the current configuration.
 
-> Note that the formatting for the member names is case insensitive, and underscores and hyphens are ignored. Hence `frameworkType`, `framework-type`, `FRAMEWORK_TYPE` and `FRAME-WORK-TYPE` all resolve to the `FrameworkType` member of `IGenerationOptions`. The rules for file finding & resolution work exactly the same as they do for `.editorConfig` files - in short, all folders from the solution file to the root are searched for a `.unitTestGeneratorConfig` file, and files 'closer' to the solution file take precedence if the same option is set in more than one file.
+Note that the formatting for the member names is case insensitive, and underscores and hyphens are ignored. Hence `frameworkType`, `framework-type`, `FRAMEWORK_TYPE` and `FRAME-WORK-TYPE` all resolve to the `FrameworkType` member of `IGenerationOptions`. The rules for file finding & resolution work exactly the same as they do for `.editorConfig` files - in short, all folders from the solution file to the root are searched for a `.unitTestGeneratorConfig` file, and files 'closer' to the solution file take precedence if the same option is set in more than one file.

--- a/docs/examples/AbstractClass.md
+++ b/docs/examples/AbstractClass.md
@@ -50,23 +50,36 @@ public class TestClassTests
     [Fact]
     public void CanCallProtectedMethod()
     {
+        // Act
         var result = _testClass.PublicProtectedMethod();
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
     [Fact]
     public void CanCallSomeMethod()
     {
+        // Arrange
         var i = 534011718;
+
+        // Act
         var result = _testClass.SomeMethod(i);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
     [Fact]
     public void CanCallGenericMethod()
     {
+        // Arrange
         var i = 237820880;
+
+        // Act
         var result = _testClass.GenericMethod<T>(i);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 }

--- a/docs/examples/AsyncMethod.md
+++ b/docs/examples/AsyncMethod.md
@@ -34,9 +34,14 @@ public class TestClassTests
     [Fact]
     public async Task CanCallThisIsAnAsyncMethod()
     {
+        // Arrange
         var methodName = "TestValue534011718";
         var methodValue = 237820880;
+
+        // Act
         await _testClass.ThisIsAnAsyncMethod(methodName, methodValue);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -52,9 +57,14 @@ public class TestClassTests
     [Fact]
     public async Task CanCallThisIsAnAsyncMethodWithReturnType()
     {
+        // Arrange
         var methodName = "TestValue1657007234";
         var methodValue = 1412011072;
+
+        // Act
         var result = await _testClass.ThisIsAnAsyncMethodWithReturnType(methodName, methodValue);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 

--- a/docs/examples/AutomaticMockGeneration.md
+++ b/docs/examples/AutomaticMockGeneration.md
@@ -91,7 +91,10 @@ public class AutomaticMockGenerationExampleTests
     [Fact]
     public void CanConstruct()
     {
+        // Act
         var instance = new AutomaticMockGenerationExample(_dummyService, _dummyService2);
+
+        // Assert
         instance.Should().NotBeNull();
     }
 
@@ -110,11 +113,14 @@ public class AutomaticMockGenerationExampleTests
     [Fact]
     public async Task CanCallSampleAsyncMethod()
     {
+        // Arrange
         _dummyService.AsyncMethod().Returns("TestValue687431273");
         _dummyService2.AsyncMethod(Arg.Any<string>()).Returns("TestValue2125508764");
 
+        // Act
         await _testClass.SampleAsyncMethod();
 
+        // Assert
         await _dummyService.Received().AsyncMethod();
         await _dummyService2.Received().AsyncMethod(Arg.Any<string>());
 
@@ -124,14 +130,17 @@ public class AutomaticMockGenerationExampleTests
     [Fact]
     public void CanCallSampleNoReturn()
     {
+        // Arrange
         var srr = "TestValue1321446349";
 
         _dummyService.GenericMethod<string>(Arg.Any<string>()).Returns("TestValue1464848243");
         _dummyService2.ReturnMethod(Arg.Any<string>(), Arg.Any<string>()).Returns(1406361028);
         _dummyService2.SomeProp.Returns("TestValue607156385");
 
+        // Act
         _testClass.SampleNoReturn(srr);
 
+        // Assert
         _dummyService.Received().NoReturnMethod();
         _dummyService.Received().GenericMethod<string>(Arg.Any<string>());
         _dummyService2.Received().ReturnMethod(Arg.Any<string>(), Arg.Any<string>());

--- a/docs/examples/ConstrainedGenericType.md
+++ b/docs/examples/ConstrainedGenericType.md
@@ -59,7 +59,10 @@ public class TestClass_2Tests
     [Fact]
     public void CanConstruct()
     {
+        // Act
         var instance = new TestClass<T, R>(_insta, _insta2);
+
+        // Assert
         instance.Should().NotBeNull();
     }
 

--- a/docs/examples/DelegateGeneration.md
+++ b/docs/examples/DelegateGeneration.md
@@ -69,8 +69,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod()
     {
+        // Arrange
         Func<string> func = () => "TestValue237820880";
+
+        // Act
         TestClass.ThisIsAMethod(func);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -83,8 +88,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod2()
     {
+        // Arrange
         Func<string, SomeClass> func = x => new SomeClass(1002897798);
+
+        // Act
         TestClass.ThisIsAMethod2(func);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -97,8 +107,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod3()
     {
+        // Arrange
         Func<int, string, SomeClass> func = (x, y) => new SomeClass(1657007234);
+
+        // Act
         TestClass.ThisIsAMethod3(func);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -111,8 +126,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod4()
     {
+        // Arrange
         Func<int, int, string, SomeClass> func = (x, y, z) => new SomeClass(1412011072);
+
+        // Act
         TestClass.ThisIsAMethod4(func);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -125,8 +145,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod5()
     {
+        // Arrange
         Func<int, int, int, string, SomeClass> func = (a, b, c, d) => new SomeClass(929393559);
+
+        // Act
         TestClass.ThisIsAMethod5(func);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -139,8 +164,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod6()
     {
+        // Arrange
         Action action = () => { };
+
+        // Act
         TestClass.ThisIsAMethod6(action);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -153,8 +183,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod7()
     {
+        // Arrange
         Action<SomeClass> action = x => { };
+
+        // Act
         TestClass.ThisIsAMethod7(action);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -167,8 +202,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod8()
     {
+        // Arrange
         Action<SomeClass, int> action = (x, y) => { };
+
+        // Act
         TestClass.ThisIsAMethod8(action);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -181,8 +221,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod9()
     {
+        // Arrange
         Action<SomeClass, int, int> action = (x, y, z) => { };
+
+        // Act
         TestClass.ThisIsAMethod9(action);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -195,8 +240,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod10()
     {
+        // Arrange
         Action<SomeClass, int, int, int> action = (a, b, c, d) => { };
+
+        // Act
         TestClass.ThisIsAMethod10(action);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -209,8 +259,13 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod11()
     {
+        // Arrange
         Action<SomeClass, int, int, int, int> action = (a, b, c, d, e) => { };
+
+        // Act
         TestClass.ThisIsAMethod11(action);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 

--- a/docs/examples/ExtensionMethod.md
+++ b/docs/examples/ExtensionMethod.md
@@ -25,8 +25,13 @@ public static class ExtensionMethodClassTests
     [Fact]
     public static void CanCallToOtherWithString()
     {
+        // Arrange
         var source = "TestValue534011718";
+
+        // Act
         var result = source.ToOther();
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -42,8 +47,13 @@ public static class ExtensionMethodClassTests
     [Fact]
     public static void CanCallToOtherWithListOfT()
     {
+        // Arrange
         var source = new List<T>();
+
+        // Act
         var result = source.ToOther<T>();
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 

--- a/docs/examples/FrameworksFluentAssertions.md
+++ b/docs/examples/FrameworksFluentAssertions.md
@@ -44,7 +44,10 @@ public class TestClassTests
     [Fact]
     public void CanConstruct()
     {
+        // Act
         var instance = new TestClass(_dependency);
+
+        // Assert
         instance.Should().NotBeNull();
     }
 
@@ -57,9 +60,14 @@ public class TestClassTests
     [Fact]
     public void CanCallSomeMethod()
     {
+        // Arrange
         var methodName = "TestValue534011718";
         var methodValue = 237820880;
+
+        // Act
         _testClass.SomeMethod(methodName, methodValue);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -75,9 +83,14 @@ public class TestClassTests
     [Fact]
     public async Task CanCallSomeAsyncMethod()
     {
+        // Arrange
         var methodName = "TestValue1657007234";
         var methodValue = 1412011072;
+
+        // Act
         var result = await _testClass.SomeAsyncMethod(methodName, methodValue);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 

--- a/docs/examples/FrameworksMsTestMoq.md
+++ b/docs/examples/FrameworksMsTestMoq.md
@@ -46,7 +46,10 @@ public class TestClassTests
     [TestMethod]
     public void CanConstruct()
     {
+        // Act
         var instance = new TestClass(_dependency.Object);
+
+        // Assert
         Assert.IsNotNull(instance);
     }
 
@@ -59,9 +62,14 @@ public class TestClassTests
     [TestMethod]
     public void CanCallSomeMethod()
     {
+        // Arrange
         var methodName = "TestValue534011718";
         var methodValue = 237820880;
+
+        // Act
         _testClass.SomeMethod(methodName, methodValue);
+
+        // Assert
         Assert.Fail("Create or modify test");
     }
 
@@ -77,9 +85,14 @@ public class TestClassTests
     [TestMethod]
     public async Task CanCallSomeAsyncMethod()
     {
+        // Arrange
         var methodName = "TestValue1657007234";
         var methodValue = 1412011072;
+
+        // Act
         var result = await _testClass.SomeAsyncMethod(methodName, methodValue);
+
+        // Assert
         Assert.Fail("Create or modify test");
     }
 

--- a/docs/examples/FrameworksNUnitFakeItEasy.md
+++ b/docs/examples/FrameworksNUnitFakeItEasy.md
@@ -46,7 +46,10 @@ public class TestClassTests
     [Test]
     public void CanConstruct()
     {
+        // Act
         var instance = new TestClass(_dependency);
+
+        // Assert
         Assert.That(instance, Is.Not.Null);
     }
 
@@ -59,9 +62,14 @@ public class TestClassTests
     [Test]
     public void CanCallSomeMethod()
     {
+        // Arrange
         var methodName = "TestValue534011718";
         var methodValue = 237820880;
+
+        // Act
         _testClass.SomeMethod(methodName, methodValue);
+
+        // Assert
         Assert.Fail("Create or modify test");
     }
 
@@ -76,9 +84,14 @@ public class TestClassTests
     [Test]
     public async Task CanCallSomeAsyncMethod()
     {
+        // Arrange
         var methodName = "TestValue1657007234";
         var methodValue = 1412011072;
+
+        // Act
         var result = await _testClass.SomeAsyncMethod(methodName, methodValue);
+
+        // Assert
         Assert.Fail("Create or modify test");
     }
 

--- a/docs/examples/FrameworksXUnitNSubstitute.md
+++ b/docs/examples/FrameworksXUnitNSubstitute.md
@@ -44,7 +44,10 @@ public class TestClassTests
     [Fact]
     public void CanConstruct()
     {
+        // Act
         var instance = new TestClass(_dependency);
+
+        // Assert
         Assert.NotNull(instance);
     }
 
@@ -57,9 +60,14 @@ public class TestClassTests
     [Fact]
     public void CanCallSomeMethod()
     {
+        // Arrange
         var methodName = "TestValue534011718";
         var methodValue = 237820880;
+
+        // Act
         _testClass.SomeMethod(methodName, methodValue);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -75,9 +83,14 @@ public class TestClassTests
     [Fact]
     public async Task CanCallSomeAsyncMethod()
     {
+        // Arrange
         var methodName = "TestValue1657007234";
         var methodValue = 1412011072;
+
+        // Act
         var result = await _testClass.SomeAsyncMethod(methodName, methodValue);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 

--- a/docs/examples/GenericMethod.md
+++ b/docs/examples/GenericMethod.md
@@ -27,11 +27,16 @@ public class GenericSourceTests
     [Fact]
     public void CanCallDoStuff()
     {
+        // Arrange
         var g = new Guid("8286d046-9740-a3e4-95cf-ff46699c73c4");
         var dtParam = DateTime.UtcNow;
         var theThing = "TestValue607156385";
         var thing2 = 1321446349;
+
+        // Act
         _testClass.DoStuff<T>(g, dtParam, theThing, thing2);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 }

--- a/docs/examples/IComparableTests.md
+++ b/docs/examples/IComparableTests.md
@@ -56,16 +56,22 @@ public class TestComparableGenericTests
     [Fact]
     public void CanConstruct()
     {
+        // Act
         var instance = new TestComparableGeneric(_value);
+
+        // Assert
         instance.Should().NotBeNull();
     }
 
     [Fact]
     public void ImplementsIComparable_TestComparableGeneric()
     {
+        // Arrange
         TestComparableGeneric baseValue = default(TestComparableGeneric);
         TestComparableGeneric equalToBaseValue = default(TestComparableGeneric);
         TestComparableGeneric greaterThanBaseValue = default(TestComparableGeneric);
+
+        // Assert
         baseValue.CompareTo(equalToBaseValue).Should().Be(0);
         baseValue.CompareTo(greaterThanBaseValue).Should().BeLessThan(0);
         greaterThanBaseValue.CompareTo(baseValue).Should().BeGreaterThan(0);
@@ -74,9 +80,12 @@ public class TestComparableGenericTests
     [Fact]
     public void ImplementsIComparable_Int32()
     {
+        // Arrange
         TestComparableGeneric baseValue = default(TestComparableGeneric);
         int equalToBaseValue = default(int);
         int greaterThanBaseValue = default(int);
+
+        // Assert
         baseValue.CompareTo(equalToBaseValue).Should().Be(0);
         baseValue.CompareTo(greaterThanBaseValue).Should().BeLessThan(0);
         greaterThanBaseValue.CompareTo(baseValue).Should().BeGreaterThan(0);
@@ -85,9 +94,12 @@ public class TestComparableGenericTests
     [Fact]
     public void ImplementsIComparable()
     {
+        // Arrange
         TestComparableGeneric baseValue = default(TestComparableGeneric);
         TestComparableGeneric equalToBaseValue = default(TestComparableGeneric);
         TestComparableGeneric greaterThanBaseValue = default(TestComparableGeneric);
+
+        // Assert
         baseValue.CompareTo(equalToBaseValue).Should().Be(0);
         baseValue.CompareTo(greaterThanBaseValue).Should().BeLessThan(0);
         greaterThanBaseValue.CompareTo(baseValue).Should().BeGreaterThan(0);
@@ -96,8 +108,13 @@ public class TestComparableGenericTests
     [Fact]
     public void CanCallCompareToWithTestComparableGeneric()
     {
+        // Arrange
         var obj = new TestComparableGeneric(237820880);
+
+        // Act
         var result = _testClass.CompareTo(obj);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -110,16 +127,26 @@ public class TestComparableGenericTests
     [Fact]
     public void CanCallCompareToWithValue()
     {
+        // Arrange
         var value = 1002897798;
+
+        // Act
         var result = _testClass.CompareTo(value);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
     [Fact]
     public void CanCallCompareToWithObject()
     {
+        // Arrange
         var obj = new object();
+
+        // Act
         var result = _testClass.CompareTo(obj);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 

--- a/docs/examples/IEquatableTests.md
+++ b/docs/examples/IEquatableTests.md
@@ -54,8 +54,11 @@ public class ComplexTests
     [Fact]
     public void ImplementsIEquatable_Complex()
     {
+        // Arrange
         var same = new Complex();
         var different = new Complex();
+
+        // Assert
         _testClass.Equals(default(object)).Should().BeFalse();
         _testClass.Equals(new object()).Should().BeFalse();
         _testClass.Equals((object)same).Should().BeTrue();
@@ -73,16 +76,26 @@ public class ComplexTests
     [Fact]
     public void CanCallEqualsWithComplex()
     {
+        // Arrange
         var other = new Complex();
+
+        // Act
         var result = _testClass.Equals(other);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
     [Fact]
     public void CanCallEqualsWithObject()
     {
+        // Arrange
         var other = new object();
+
+        // Act
         var result = _testClass.Equals(other);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -95,41 +108,64 @@ public class ComplexTests
     [Fact]
     public void CanCallGetHashCode()
     {
+        // Act
         var result = _testClass.GetHashCode();
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
     [Fact]
     public void CanCallEqualityOperator()
     {
+        // Arrange
         var term1 = new Complex();
         var term2 = new Complex();
+
+        // Act
         var result = term1 == term2;
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
     [Fact]
     public void CanCallInequalityOperator()
     {
+        // Arrange
         var term1 = new Complex();
         var term2 = new Complex();
+
+        // Act
         var result = term1 != term2;
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
     [Fact]
     public void CanSetAndGetRealPart()
     {
+        // Arrange
         var testValue = 528671600.82;
+
+        // Act
         _testClass.RealPart = testValue;
+
+        // Assert
         _testClass.RealPart.Should().Be(testValue);
     }
 
     [Fact]
     public void CanSetAndGetImaginaryPart()
     {
+        // Arrange
         var testValue = 235442671.2;
+
+        // Act
         _testClass.ImaginaryPart = testValue;
+
+        // Assert
         _testClass.ImaginaryPart.Should().Be(testValue);
     }
 }

--- a/docs/examples/MappingMethod.md
+++ b/docs/examples/MappingMethod.md
@@ -41,8 +41,13 @@ public class MappingClassTests
     [Fact]
     public void CanCallMap()
     {
+        // Arrange
         var inputClass = new InputClass { SomeOtherProperty = "TestValue929393559", InputOnlyProperty = "TestValue760389092" };
+
+        // Act
         var result = _testClass.Map(inputClass);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -55,8 +60,13 @@ public class MappingClassTests
     [Fact]
     public void MapPerformsMapping()
     {
+        // Arrange
         var inputClass = new InputClass { SomeOtherProperty = "TestValue2026928803", InputOnlyProperty = "TestValue217468053" };
+
+        // Act
         var result = _testClass.Map(inputClass);
+
+        // Assert
         result.SomeProperty.Should().BeSameAs(inputClass.SomeProperty);
         result.SomeOtherProperty.Should().BeSameAs(inputClass.SomeOtherProperty);
     }

--- a/docs/examples/MultipleOverloads.md
+++ b/docs/examples/MultipleOverloads.md
@@ -30,9 +30,14 @@ public static class FluentFactoryTests
     [Fact]
     public static void CanCallFollows()
     {
+        // Arrange
         var stage = Stage.First;
         var followedStages = new[] { Stage.First, Stage.Second, Stage.Fourth };
+
+        // Act
         var result = stage.Follows(followedStages);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -45,9 +50,14 @@ public static class FluentFactoryTests
     [Fact]
     public static void CanCallAndWithFirstConstraintAndSecondConstraint()
     {
+        // Arrange
         var firstConstraint = new Tuple<Stage, IList<Stage>>(Stage.Second, new[] { Stage.Second, Stage.Fourth, Stage.First });
         var secondConstraint = new Tuple<Stage, IList<Stage>>(Stage.Third, new[] { Stage.First, Stage.First, Stage.Second });
+
+        // Act
         var result = firstConstraint.And(secondConstraint);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -66,9 +76,14 @@ public static class FluentFactoryTests
     [Fact]
     public static void CanCallAndWithConstraintsAndAdditionalConstraint()
     {
+        // Arrange
         var constraints = Substitute.For<IDictionary<Stage, IList<Stage>>>();
         var additionalConstraint = new Tuple<Stage, IList<Stage>>(Stage.First, new[] { Stage.First, Stage.Second, Stage.Fourth });
+
+        // Act
         var result = constraints.And(additionalConstraint);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 

--- a/docs/examples/NullableReferenceTypes.md
+++ b/docs/examples/NullableReferenceTypes.md
@@ -52,11 +52,22 @@ public class TestClassTests
     [Fact]
     public void CanConstruct()
     {
+        // Act
         var instance = new TestClass(_notNullable, _nullable);
+
+        // Assert
         instance.Should().NotBeNull();
+
+        // Act
         instance = new TestClass(_testITest);
+
+        // Assert
         instance.Should().NotBeNull();
+
+        // Act
         instance = new TestClass(_testITest, _someOtherThing);
+
+        // Assert
         instance.Should().NotBeNull();
     }
 
@@ -95,10 +106,15 @@ public class TestClassTests
     [Fact]
     public void CanCallGetFullName()
     {
+        // Arrange
         var first = "TestValue760389092";
         var middle = "TestValue2026928803";
         var last = "TestValue217468053";
+
+        // Act
         var result = _testClass.GetFullName(first, middle, last);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -131,9 +147,14 @@ public class TestClassTests
     [Fact]
     public void CanCallSomeMethod()
     {
+        // Arrange
         var test = Substitute.For<ITest>();
         var someOtherThing = "TestValue1406361028";
+
+        // Act
         _testClass.SomeMethod(test, someOtherThing);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -155,8 +176,13 @@ public class TestClassTests
     [Fact]
     public void CanCallMethodForWhichNoNullabilityTestShouldBeEmitted()
     {
+        // Arrange
         var test = Substitute.For<ITest>();
+
+        // Act
         _testClass.MethodForWhichNoNullabilityTestShouldBeEmitted(test);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 }

--- a/docs/examples/OperatorOverloading.md
+++ b/docs/examples/OperatorOverloading.md
@@ -66,16 +66,24 @@ public class CalculatorTests
     [Fact]
     public void CanConstruct()
     {
+        // Act
         var instance = new Calculator(_n);
+
+        // Assert
         instance.Should().NotBeNull();
     }
 
     [Fact]
     public void CanCallPlusOperator()
     {
+        // Arrange
         var Calc1 = new Calculator(237820880);
         var Calc2 = new Calculator(1002897798);
+
+        // Act
         var result = Calc1 + Calc2;
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -94,9 +102,14 @@ public class CalculatorTests
     [Fact]
     public void CanCallMinusOperator()
     {
+        // Arrange
         var Calc1 = new Calculator(929393559);
         var Calc2 = new Calculator(760389092);
+
+        // Act
         var result = Calc1 - Calc2;
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -115,8 +128,13 @@ public class CalculatorTests
     [Fact]
     public void CanCallUnaryMinusOperator()
     {
+        // Arrange
         var Calc1 = new Calculator(1379662799);
+
+        // Act
         var result = -Calc1;
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -129,9 +147,14 @@ public class CalculatorTests
     [Fact]
     public void CanCallMultiplicationOperator()
     {
+        // Arrange
         var Calc1 = new Calculator(61497087);
         var Calc2 = new Calculator(532638534);
+
+        // Act
         var result = Calc1 * Calc2;
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -150,9 +173,14 @@ public class CalculatorTests
     [Fact]
     public void CanCallDivisionOperator()
     {
+        // Arrange
         var Calc1 = new Calculator(1464848243);
         var Calc2 = new Calculator(1406361028);
+
+        // Act
         var result = Calc1 / Calc2;
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 

--- a/docs/examples/PocoInitialization.md
+++ b/docs/examples/PocoInitialization.md
@@ -40,7 +40,10 @@ public class ConsumingClassTests
     [Fact]
     public void CanConstruct()
     {
+        // Act
         var instance = new ConsumingClass(_poco);
+
+        // Assert
         instance.Should().NotBeNull();
     }
 

--- a/docs/examples/PropertyInitializationChecks.md
+++ b/docs/examples/PropertyInitializationChecks.md
@@ -1,0 +1,77 @@
+﻿# Property Initialization Checks
+Demonstrates how properties that have matching constructor parameters are checked that they are initialized automatically
+
+### Source Type(s)
+``` csharp
+public class ExampleClass
+{
+    public ExampleClass(int identity, string description, Guid uniqueCode)
+    {
+        Identity = identity;
+        Description = description;
+        UniqueCode = uniqueCode;
+    }
+
+    public int Identity { get; }
+    public string Description { get; }
+    public Guid UniqueCode { get; }
+}
+
+```
+
+### Generated Tests
+``` csharp
+public class ExampleClassTests
+{
+    private ExampleClass _testClass;
+    private int _identity;
+    private string _description;
+    private Guid _uniqueCode;
+
+    public ExampleClassTests()
+    {
+        _identity = 534011718;
+        _description = "TestValue237820880";
+        _uniqueCode = new Guid("97408286-a3e4-cf95-ff46-699c73c4a1cd");
+        _testClass = new ExampleClass(_identity, _description, _uniqueCode);
+    }
+
+    [Fact]
+    public void CanConstruct()
+    {
+        // Act
+        var instance = new ExampleClass(_identity, _description, _uniqueCode);
+
+        // Assert
+        instance.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CannotConstructWithInvalidDescription(string value)
+    {
+        FluentActions.Invoking(() => new ExampleClass(1512368656, value, new Guid("4e5b1334-6fa3-a584-4adf-7a0ea09ce3c1"))).Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void IdentityIsInitializedCorrectly()
+    {
+        _testClass.Identity.Should().Be(_identity);
+    }
+
+    [Fact]
+    public void DescriptionIsInitializedCorrectly()
+    {
+        _testClass.Description.Should().Be(_description);
+    }
+
+    [Fact]
+    public void UniqueCodeIsInitializedCorrectly()
+    {
+        _testClass.UniqueCode.Should().Be(_uniqueCode);
+    }
+}
+
+```

--- a/docs/examples/RecordTypeInitProperties.md
+++ b/docs/examples/RecordTypeInitProperties.md
@@ -53,7 +53,10 @@ public class PersonTests
     [Fact]
     public void CanInitialize()
     {
+        // Act
         var instance = new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours };
+
+        // Assert
         instance.Should().NotBeNull();
     }
 
@@ -92,8 +95,11 @@ public class PersonTests
     [Fact]
     public void ImplementsIEquatable_Person()
     {
+        // Arrange
         var same = new Person { Id = _id, FirstName = _firstName, MiddleName = _middleName, LastName = _lastName, IceCreamFlavours = _iceCreamFlavours };
         var different = new Person();
+
+        // Assert
         _testClass.Equals(default(object)).Should().BeFalse();
         _testClass.Equals(new object()).Should().BeFalse();
         _testClass.Equals((object)same).Should().BeTrue();

--- a/docs/examples/RecordTypesPrimaryConstructor.md
+++ b/docs/examples/RecordTypesPrimaryConstructor.md
@@ -25,15 +25,21 @@ public class RecordTypeTests
     [Fact]
     public void CanConstruct()
     {
+        // Act
         var instance = new RecordType(_stringProperty, _intProperty);
+
+        // Assert
         instance.Should().NotBeNull();
     }
 
     [Fact]
     public void ImplementsIEquatable_RecordType()
     {
+        // Arrange
         var same = new RecordType(_stringProperty, _intProperty);
         var different = new RecordType("TestValue1002897798", 1657007234);
+
+        // Assert
         _testClass.Equals(default(object)).Should().BeFalse();
         _testClass.Equals(new object()).Should().BeFalse();
         _testClass.Equals((object)same).Should().BeTrue();

--- a/docs/examples/RefAndOutParameters.md
+++ b/docs/examples/RefAndOutParameters.md
@@ -42,9 +42,14 @@ public class TestClassTests
     [Fact]
     public void CanCallRefParamMethodString()
     {
+        // Arrange
         var stringProp = "TestValue534011718";
         var refParam = "TestValue237820880";
+
+        // Act
         _testClass.RefParamMethodString(stringProp, ref refParam);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -71,8 +76,13 @@ public class TestClassTests
     [Fact]
     public void CanCallOutParamMethodString()
     {
+        // Arrange
         var stringProp = "TestValue929393559";
+
+        // Act
         _testClass.OutParamMethodString(stringProp, out var outParam);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -88,9 +98,14 @@ public class TestClassTests
     [Fact]
     public void CanCallRefParamMethodClass()
     {
+        // Arrange
         var stringProp = "TestValue760389092";
         var refParam = new TestClass();
+
+        // Act
         _testClass.RefParamMethodClass(stringProp, ref refParam);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -114,8 +129,13 @@ public class TestClassTests
     [Fact]
     public void CanCallOutParamMethodClass()
     {
+        // Arrange
         var stringProp = "TestValue217468053";
+
+        // Act
         _testClass.OutParamMethodClass(stringProp, out var outParam);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 

--- a/docs/examples/SimplePoco.md
+++ b/docs/examples/SimplePoco.md
@@ -26,24 +26,39 @@ public class SomePocoTests
     [Fact]
     public void CanSetAndGetIdentity()
     {
+        // Arrange
         var testValue = 534011718;
+
+        // Act
         _testClass.Identity = testValue;
+
+        // Assert
         _testClass.Identity.Should().Be(testValue);
     }
 
     [Fact]
     public void CanSetAndGetDescription()
     {
+        // Arrange
         var testValue = "TestValue237820880";
+
+        // Act
         _testClass.Description = testValue;
+
+        // Assert
         _testClass.Description.Should().Be(testValue);
     }
 
     [Fact]
     public void CanSetAndGetUniqueCode()
     {
+        // Arrange
         var testValue = new Guid("97408286-a3e4-cf95-ff46-699c73c4a1cd");
+
+        // Act
         _testClass.UniqueCode = testValue;
+
+        // Assert
         _testClass.UniqueCode.Should().Be(testValue);
     }
 }

--- a/docs/examples/Singleton.md
+++ b/docs/examples/Singleton.md
@@ -40,8 +40,13 @@ public class TestClassTests
     [Fact]
     public void CanCallGetTableName()
     {
+        // Arrange
         var baseName = "TestValue534011718";
+
+        // Act
         var result = _testClass.GetTableName(baseName);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -57,14 +62,20 @@ public class TestClassTests
     [Fact]
     public void CanGetInstance()
     {
+        // Assert
         TestClass.Instance.Should().BeAssignableTo<TestClass>();
+
+        // Arrange
         throw new NotImplementedException("Create or modify test");
     }
 
     [Fact]
     public void CanGetIsShared()
     {
+        // Assert
         _testClass.IsShared.As<object>().Should().BeAssignableTo<bool>();
+
+        // Arrange
         throw new NotImplementedException("Create or modify test");
     }
 }

--- a/docs/examples/Singleton.md
+++ b/docs/examples/Singleton.md
@@ -65,7 +65,6 @@ public class TestClassTests
         // Assert
         TestClass.Instance.Should().BeAssignableTo<TestClass>();
 
-        // Arrange
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -75,7 +74,6 @@ public class TestClassTests
         // Assert
         _testClass.IsShared.As<object>().Should().BeAssignableTo<bool>();
 
-        // Arrange
         throw new NotImplementedException("Create or modify test");
     }
 }

--- a/docs/examples/StaticClass.md
+++ b/docs/examples/StaticClass.md
@@ -29,9 +29,14 @@ public static class TestClassTests
     [Fact]
     public static void CanCallThisIsAMethod()
     {
+        // Arrange
         var methodName = "TestValue534011718";
         var methodValue = CultureInfo.InvariantCulture;
+
+        // Act
         TestClass.ThisIsAMethod(methodName, methodValue);
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
@@ -53,22 +58,33 @@ public static class TestClassTests
     [Fact]
     public static void CanCallWillReturnAString()
     {
+        // Act
         var result = TestClass.WillReturnAString();
+
+        // Assert
         throw new NotImplementedException("Create or modify test");
     }
 
     [Fact]
     public static void CanSetAndGetThisIsAProperty()
     {
+        // Arrange
         var testValue = 1412011072;
+
+        // Act
         TestClass.ThisIsAProperty = testValue;
+
+        // Assert
         TestClass.ThisIsAProperty.Should().Be(testValue);
     }
 
     [Fact]
     public static void CanGetGetITest()
     {
+        // Assert
         TestClass.GetITest.Should().BeAssignableTo<string>();
+
+        // Arrange
         throw new NotImplementedException("Create or modify test");
     }
 }

--- a/docs/examples/StaticClass.md
+++ b/docs/examples/StaticClass.md
@@ -84,7 +84,6 @@ public static class TestClassTests
         // Assert
         TestClass.GetITest.Should().BeAssignableTo<string>();
 
-        // Arrange
         throw new NotImplementedException("Create or modify test");
     }
 }

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -22,6 +22,7 @@ This section contains examples of the output that Unitverse outputs, refreshed e
 | [Nullable Reference Types](NullableReferenceTypes.md) | Shows how Unitverse will omit `null` tests for parameters declared to explicitly accept null |
 | [Operator Overloading](OperatorOverloading.md) | Shows how Unitverse emits tests for declared unary and binary operators |
 | [POCO Initialization](PocoInitialization.md) | Demonstrates how test values are produced to initialize POCO members when the type is consumed |
+| [Property Initialization Checks](PropertyInitializationChecks.md) | Demonstrates how properties that have matching constructor parameters are checked that they are initialized automatically |
 | [Record Types (init Properties)](RecordTypeInitProperties.md) | Demonstrates the tests generated for a record type that has properties that have init accessors |
 | [Record Types (Primary Constructor)](RecordTypesPrimaryConstructor.md) | Demonstrates the tests generated for a simple primary constructor record type |
 | [ref & out Parameters](RefAndOutParameters.md) | Demonstrates the tests that Unitverse emits when methods contain `ref` or `out` parameters |

--- a/src/Unitverse.Core.Tests/DefaultGenerationOptions.cs
+++ b/src/Unitverse.Core.Tests/DefaultGenerationOptions.cs
@@ -29,5 +29,11 @@
         public bool AutomaticallyConfigureMocks => true;
 
         public bool EmitSubclassForProtectedMethods => true;
+
+        public string ArrangeComment => "Arrange";
+
+        public string ActComment => "Act";
+
+        public string AssertComment => "Assert";
     }
 }

--- a/src/Unitverse.Core.Tests/Frameworks/Test/MsTestTestFrameworkTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/Test/MsTestTestFrameworkTests.cs
@@ -5,6 +5,8 @@ namespace Unitverse.Core.Tests.Frameworks.Test
     using System;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.CSharp;
+    using NSubstitute;
+    using Unitverse.Core.Options;
 
     [TestFixture]
     public class MsTestTestFrameworkTests
@@ -14,7 +16,7 @@ namespace Unitverse.Core.Tests.Frameworks.Test
         [SetUp]
         public void SetUp()
         {
-            _testClass = new MsTestTestFramework();
+            _testClass = new MsTestTestFramework(Substitute.For<IUnitTestGeneratorOptions>());
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Frameworks/Test/NUnit2TestFrameworkTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/Test/NUnit2TestFrameworkTests.cs
@@ -1,7 +1,9 @@
 namespace Unitverse.Core.Tests.Frameworks.Test
 {
+    using NSubstitute;
     using NUnit.Framework;
     using Unitverse.Core.Frameworks.Test;
+    using Unitverse.Core.Options;
 
     [TestFixture]
     public class NUnit2TestFrameworkTests
@@ -11,7 +13,7 @@ namespace Unitverse.Core.Tests.Frameworks.Test
         [SetUp]
         public void SetUp()
         {
-            _testClass = new NUnit2TestFramework();
+            _testClass = new NUnit2TestFramework(Substitute.For<IUnitTestGeneratorOptions>());
         }
     }
 }

--- a/src/Unitverse.Core.Tests/Frameworks/Test/NUnit3TestFrameworkTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/Test/NUnit3TestFrameworkTests.cs
@@ -1,7 +1,9 @@
 namespace Unitverse.Core.Tests.Frameworks.Test
 {
+    using NSubstitute;
     using NUnit.Framework;
     using Unitverse.Core.Frameworks.Test;
+    using Unitverse.Core.Options;
 
     [TestFixture]
     public class NUnit3TestFrameworkTests
@@ -11,7 +13,7 @@ namespace Unitverse.Core.Tests.Frameworks.Test
         [SetUp]
         public void SetUp()
         {
-            _testClass = new NUnit3TestFramework();
+            _testClass = new NUnit3TestFramework(Substitute.For<IUnitTestGeneratorOptions>());
         }
     }
 }

--- a/src/Unitverse.Core.Tests/Frameworks/Test/NUnitTestFrameworkTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/Test/NUnitTestFrameworkTests.cs
@@ -1,14 +1,20 @@
 namespace Unitverse.Core.Tests.Frameworks.Test
 {
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using NSubstitute;
     using NUnit.Framework;
     using Unitverse.Core.Frameworks.Test;
+    using Unitverse.Core.Options;
 
     [TestFixture]
     public class NUnitTestFrameworkTests
     {
         private class TestNUnitTestFramework : NUnitTestFramework
         {
+            public TestNUnitTestFramework(IUnitTestGeneratorOptions options) : base(options)
+            {
+            }
+
             public override AttributeSyntax SingleThreadedApartmentAttribute { get; }
         }
 
@@ -17,7 +23,7 @@ namespace Unitverse.Core.Tests.Frameworks.Test
         [SetUp]
         public void SetUp()
         {
-            _testClass = new TestNUnitTestFramework();
+            _testClass = new TestNUnitTestFramework(Substitute.For<IUnitTestGeneratorOptions>());
         }
     }
 }

--- a/src/Unitverse.Core.Tests/Frameworks/Test/TestFrameworkTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/Test/TestFrameworkTests.cs
@@ -6,6 +6,7 @@ namespace Unitverse.Core.Tests.Frameworks.Test
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using NSubstitute;
     using NUnit.Framework;
     using Unitverse.Core.Frameworks;
     using Unitverse.Core.Frameworks.Test;
@@ -19,10 +20,10 @@ namespace Unitverse.Core.Tests.Frameworks.Test
         {
             get
             {
-                yield return new MsTestTestFramework();
-                yield return new NUnit2TestFramework();
-                yield return new NUnit3TestFramework();
-                yield return new XUnitTestFramework();
+                yield return new MsTestTestFramework(Substitute.For<IUnitTestGeneratorOptions>());
+                yield return new NUnit2TestFramework(Substitute.For<IUnitTestGeneratorOptions>());
+                yield return new NUnit3TestFramework(Substitute.For<IUnitTestGeneratorOptions>());
+                yield return new XUnitTestFramework(Substitute.For<IUnitTestGeneratorOptions>());
             }
         }
 
@@ -164,7 +165,7 @@ namespace Unitverse.Core.Tests.Frameworks.Test
             var valueType = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword));
             var testValues = new object[] { 1, 2 };
             var result = testClass.CreateTestCaseMethod(new NameResolver(name), new NamingContext("class"), isAsync, isStatic, valueType, testValues);
-            Assert.That(result.NormalizeWhitespace().ToFullString(), Is.EqualTo(expectedOutput));
+            Assert.That(result.Method.NormalizeWhitespace().ToFullString(), Is.EqualTo(expectedOutput));
         }
 
         [TestCase(TestFrameworkTypes.NUnit2, "[Test]\r\npublic static void TestValue1606901338()")]
@@ -178,7 +179,7 @@ namespace Unitverse.Core.Tests.Frameworks.Test
             var isAsync = false;
             var isStatic = true;
             var result = testClass.CreateTestMethod(new NameResolver(name), new NamingContext("class"), isAsync, isStatic);
-            Assert.That(result.NormalizeWhitespace().ToFullString(), Is.EqualTo(expectedOutput));
+            Assert.That(result.Method.NormalizeWhitespace().ToFullString(), Is.EqualTo(expectedOutput));
         }
 
         [TestCase(TestFrameworkTypes.NUnit2, "NUnit.Framework")]
@@ -307,13 +308,13 @@ namespace Unitverse.Core.Tests.Frameworks.Test
             switch (frameworkTypes)
             {
                 case TestFrameworkTypes.MsTest:
-                    return new MsTestTestFramework();
+                    return new MsTestTestFramework(Substitute.For<IUnitTestGeneratorOptions>());
                 case TestFrameworkTypes.NUnit2:
-                    return new NUnit2TestFramework();
+                    return new NUnit2TestFramework(Substitute.For<IUnitTestGeneratorOptions>());
                 case TestFrameworkTypes.NUnit3:
-                    return new NUnit3TestFramework();
+                    return new NUnit3TestFramework(Substitute.For<IUnitTestGeneratorOptions>());
                 case TestFrameworkTypes.XUnit:
-                    return new XUnitTestFramework();
+                    return new XUnitTestFramework(Substitute.For<IUnitTestGeneratorOptions>());
                 default:
                     throw new ArgumentOutOfRangeException(nameof(frameworkTypes));
             }

--- a/src/Unitverse.Core.Tests/Frameworks/Test/XUnitTestFrameworkTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/Test/XUnitTestFrameworkTests.cs
@@ -1,7 +1,9 @@
 namespace Unitverse.Core.Tests.Frameworks.Test
 {
+    using NSubstitute;
     using NUnit.Framework;
     using Unitverse.Core.Frameworks.Test;
+    using Unitverse.Core.Options;
 
     [TestFixture]
     public class XUnitTestFrameworkTests
@@ -11,7 +13,7 @@ namespace Unitverse.Core.Tests.Frameworks.Test
         [SetUp]
         public void SetUp()
         {
-            _testClass = new XUnitTestFramework();
+            _testClass = new XUnitTestFramework(Substitute.For<IUnitTestGeneratorOptions>());
         }
     }
 }

--- a/src/Unitverse.Core.Tests/Helpers/SectionedMethodHandlerTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/SectionedMethodHandlerTests.cs
@@ -1,0 +1,159 @@
+namespace Unitverse.Core.Tests.Helpers
+{
+    using Unitverse.Core.Helpers;
+    using System;
+    using NUnit.Framework;
+    using FluentAssertions;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using System.Collections.Generic;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis;
+    using System.Linq;
+    using Microsoft.CodeAnalysis.Formatting;
+
+    [TestFixture]
+    public class SectionedMethodHandlerTests
+    {
+        private SectionedMethodHandler _testClass;
+        private MethodDeclarationSyntax _method;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _method = SyntaxFactory.MethodDeclaration(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)), "method");
+            _testClass = new SectionedMethodHandler(_method);
+        }
+
+        [Test]
+        public void CannotConstructWithNullMethod()
+        {
+            FluentActions.Invoking(() => new SectionedMethodHandler(default(MethodDeclarationSyntax))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void SingleTransition()
+        {
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            AssertOutput("// Arrange", "var someVar = 5;");
+        }
+
+        [Test]
+        public void EndingBlankLine()
+        {
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.BlankLine();
+            AssertOutput("// Arrange", "var someVar = 5;");
+        }
+
+        [Test]
+        public void DoubleTransition()
+        {
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.Act(Generate.ImplicitlyTypedVariableDeclaration("someVar2", Generate.Literal(6)));
+            AssertOutput("// Arrange", "var someVar = 5;", "", "// Act", "var someVar2 = 6;");
+        }
+
+        [Test]
+        public void DoubleTransitionExplicitBlank()
+        {
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.BlankLine();
+            _testClass.Act(Generate.ImplicitlyTypedVariableDeclaration("someVar2", Generate.Literal(6)));
+            AssertOutput("// Arrange", "var someVar = 5;", "", "// Act", "var someVar2 = 6;");
+        }
+
+        [Test]
+        public void DoubleTransitionStupidBlank()
+        {
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.BlankLine();
+            _testClass.BlankLine();
+            _testClass.BlankLine();
+            _testClass.BlankLine();
+            _testClass.BlankLine();
+            _testClass.Act(Generate.ImplicitlyTypedVariableDeclaration("someVar2", Generate.Literal(6)));
+            AssertOutput("// Arrange", "var someVar = 5;", "", "// Act", "var someVar2 = 6;");
+        }
+
+        [Test]
+        public void PlainEmit()
+        {
+            _testClass.Emit(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            AssertOutput("var someVar = 5;");
+        }
+
+        [Test]
+        public void PlainEmitBlankLines()
+        {
+            _testClass.Emit(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.BlankLine();
+            _testClass.Emit(Generate.ImplicitlyTypedVariableDeclaration("someVar2", Generate.Literal(6)));
+            AssertOutput("var someVar = 5;", "", "var someVar2 = 6;");
+        }
+
+        private void AssertOutput(params string[] expectedOutput)
+        {
+            using (var workspace = new AdhocWorkspace())
+            {
+                var type = SyntaxFactory.ClassDeclaration(SyntaxFactory.Identifier("cls")).AddMembers(_testClass.Method);
+                var targetNamespace = SyntaxFactory.NamespaceDeclaration(SyntaxFactory.IdentifierName("namespace")).AddMembers(type);
+                var compilation = SyntaxFactory.CompilationUnit().AddMembers(targetNamespace);
+                
+                compilation = (CompilationUnitSyntax)Formatter.Format(compilation, workspace);
+
+                var methodAsText = compilation.ToFullString().Lines().ToList();
+                var refinedLines = methodAsText.Skip(6).Take(methodAsText.Count - 9).Select(x => x.Trim()).ToList();
+                refinedLines.Should().BeEquivalentTo(expectedOutput);
+            }
+
+        }
+
+        [Test]
+        public void CannotCallArrangeWithStatementSyntaxWithNullStatement()
+        {
+            FluentActions.Invoking(() => _testClass.Arrange(default(StatementSyntax))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CannotCallArrangeWithIEnumerableOfStatementSyntaxWithNullStatements()
+        {
+            FluentActions.Invoking(() => _testClass.Arrange(default(IEnumerable<StatementSyntax>))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CannotCallActWithNullStatement()
+        {
+            FluentActions.Invoking(() => _testClass.Act(default(StatementSyntax))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CannotCallAssertWithStatementSyntaxWithNullStatement()
+        {
+            FluentActions.Invoking(() => _testClass.Assert(default(StatementSyntax))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CannotCallAssertWithIEnumerableOfStatementSyntaxWithNullStatements()
+        {
+            FluentActions.Invoking(() => _testClass.Assert(default(IEnumerable<StatementSyntax>))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CannotCallEmitWithStatementSyntaxWithNullStatement()
+        {
+            FluentActions.Invoking(() => _testClass.Emit(default(StatementSyntax))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CannotCallEmitWithIEnumerableOfStatementSyntaxWithNullStatements()
+        {
+            FluentActions.Invoking(() => _testClass.Emit(default(IEnumerable<StatementSyntax>))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void MethodIsInitializedCorrectly()
+        {
+            _testClass.Method.Should().BeSameAs(_method);
+        }
+    }
+}

--- a/src/Unitverse.Core.Tests/Helpers/SectionedMethodHandlerTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/SectionedMethodHandlerTests.cs
@@ -21,13 +21,81 @@ namespace Unitverse.Core.Tests.Helpers
         public void SetUp()
         {
             _method = SyntaxFactory.MethodDeclaration(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)), "method");
-            _testClass = new SectionedMethodHandler(_method);
+            _testClass = new SectionedMethodHandler(_method, "Arrange", "Act", "Assert");
         }
 
         [Test]
         public void CannotConstructWithNullMethod()
         {
             FluentActions.Invoking(() => new SectionedMethodHandler(default(MethodDeclarationSyntax))).Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void SingleTransitionNoComments()
+        {
+            _testClass = new SectionedMethodHandler(_method, null, null, null);
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            AssertOutput("var someVar = 5;");
+        }
+
+        [Test]
+        public void EndingBlankLineNoComments()
+        {
+            _testClass = new SectionedMethodHandler(_method, null, null, null);
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.BlankLine();
+            AssertOutput("var someVar = 5;");
+        }
+
+        [Test]
+        public void DoubleTransitionNoComments()
+        {
+            _testClass = new SectionedMethodHandler(_method, null, null, null);
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.Act(Generate.ImplicitlyTypedVariableDeclaration("someVar2", Generate.Literal(6)));
+            AssertOutput("var someVar = 5;", "", "var someVar2 = 6;");
+        }
+
+        [Test]
+        public void DoubleTransitionExplicitBlankNoComments()
+        {
+            _testClass = new SectionedMethodHandler(_method, null, null, null);
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.BlankLine();
+            _testClass.Act(Generate.ImplicitlyTypedVariableDeclaration("someVar2", Generate.Literal(6)));
+            AssertOutput("var someVar = 5;", "", "var someVar2 = 6;");
+        }
+
+        [Test]
+        public void DoubleTransitionStupidBlankNoComments()
+        {
+            _testClass = new SectionedMethodHandler(_method, null, null, null);
+            _testClass.Arrange(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.BlankLine();
+            _testClass.BlankLine();
+            _testClass.BlankLine();
+            _testClass.BlankLine();
+            _testClass.BlankLine();
+            _testClass.Act(Generate.ImplicitlyTypedVariableDeclaration("someVar2", Generate.Literal(6)));
+            AssertOutput("var someVar = 5;", "", "var someVar2 = 6;");
+        }
+
+        [Test]
+        public void PlainEmitNoComments()
+        {
+            _testClass = new SectionedMethodHandler(_method, null, null, null);
+            _testClass.Emit(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            AssertOutput("var someVar = 5;");
+        }
+
+        [Test]
+        public void PlainEmitBlankLinesNoComments()
+        {
+            _testClass = new SectionedMethodHandler(_method, null, null, null);
+            _testClass.Emit(Generate.ImplicitlyTypedVariableDeclaration("someVar", Generate.Literal(5)));
+            _testClass.BlankLine();
+            _testClass.Emit(Generate.ImplicitlyTypedVariableDeclaration("someVar2", Generate.Literal(6)));
+            AssertOutput("var someVar = 5;", "", "var someVar2 = 6;");
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Helpers/SectionedMethodHandlerTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/SectionedMethodHandlerTests.cs
@@ -27,7 +27,7 @@ namespace Unitverse.Core.Tests.Helpers
         [Test]
         public void CannotConstructWithNullMethod()
         {
-            FluentActions.Invoking(() => new SectionedMethodHandler(default(MethodDeclarationSyntax))).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => new SectionedMethodHandler(default(MethodDeclarationSyntax), "Arrange", "Act", "Assert")).Should().Throw<ArgumentNullException>();
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Resources/CommentControl.txt
+++ b/src/Unitverse.Core.Tests/Resources/CommentControl.txt
@@ -1,0 +1,14 @@
+// # Arrange=Set it up yo
+// # Act=Do that funky thang
+// # Assert=Check everything went exactly amazingly
+
+namespace TestNamespace.SubNameSpace
+{
+    public class TestClass
+    {
+	    public void ThisIsAMethod(string methodName, int methodValue)
+	    {
+		    System.Console.WriteLine("Testing this");
+	    }
+    }
+}

--- a/src/Unitverse.Core.Tests/Resources/CommentControl.txt
+++ b/src/Unitverse.Core.Tests/Resources/CommentControl.txt
@@ -1,6 +1,6 @@
-// # Arrange=Set it up yo
-// # Act=Do that funky thang
-// # Assert=Check everything went exactly amazingly
+// # ArrangeComment=Set it up yo
+// # ActComment=Do that funky thang
+// # AssertComment=Check everything went exactly amazingly
 
 namespace TestNamespace.SubNameSpace
 {

--- a/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/ComparableGenerationStrategyTests.cs
+++ b/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/ComparableGenerationStrategyTests.cs
@@ -26,7 +26,7 @@ namespace Unitverse.Core.Tests.Strategies.InterfaceGeneration
 
             var options = Substitute.For<INamingOptions>();
             options.ImplementsIComparableNamingPattern.Returns("ImplementsIComparable{0}");
-            _frameworkSet = new FrameworkSet(new NUnit3TestFramework(), new NSubstituteMockingFramework(generationContext), new NUnit3TestFramework(), new NamingProvider(options), generationContext, "{0}Tests", Substitute.For<IUnitTestGeneratorOptions>());
+            _frameworkSet = new FrameworkSet(new NUnit3TestFramework(Substitute.For<IUnitTestGeneratorOptions>()), new NSubstituteMockingFramework(generationContext), new NUnit3TestFramework(Substitute.For<IUnitTestGeneratorOptions>()), new NamingProvider(options), generationContext, "{0}Tests", Substitute.For<IUnitTestGeneratorOptions>());
             _testClass = new ComparableGenerationStrategy(_frameworkSet);
         }
 

--- a/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/EquatableGenerationStrategyTests.cs
+++ b/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/EquatableGenerationStrategyTests.cs
@@ -11,6 +11,7 @@ namespace Unitverse.Core.Tests.Strategies.InterfaceGeneration
     using Unitverse.Core.Options;
     using Unitverse.Core.Frameworks;
     using System.Linq;
+    using Microsoft.CodeAnalysis.CSharp;
 
     [TestFixture]
     public class EquatableGenerationStrategyTests
@@ -21,9 +22,9 @@ namespace Unitverse.Core.Tests.Strategies.InterfaceGeneration
             {
             }
 
-            public IEnumerable<StatementSyntax> PublicGetBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel)
+            public void PublicAddBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel)
             {
-                return base.GetBodyStatements(sourceModel, interfaceModel);
+                base.AddBodyStatements(sourceModel, interfaceModel, new Core.Helpers.SectionedMethodHandler(SyntaxFactory.MethodDeclaration(SyntaxFactory.IdentifierName("string"), "id")));
             }
 
             public NameResolver PublicGeneratedMethodNamePattern => base.GeneratedMethodNamePattern;
@@ -55,13 +56,13 @@ namespace Unitverse.Core.Tests.Strategies.InterfaceGeneration
         [Test]
         public void CannotCallGetBodyStatementsWithNullSourceModel()
         {
-            FluentActions.Invoking(() => _testClass.PublicGetBodyStatements(default(ClassModel), Substitute.For<IInterfaceModel>()).ToList()).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => _testClass.PublicAddBodyStatements(default(ClassModel), Substitute.For<IInterfaceModel>())).Should().Throw<ArgumentNullException>();
         }
 
         [Test]
         public void CannotCallGetBodyStatementsWithNullInterfaceModel()
         {
-            FluentActions.Invoking(() => _testClass.PublicGetBodyStatements(new ClassModel(TestSemanticModelFactory.Class, TestSemanticModelFactory.Model, true), default(IInterfaceModel)).ToList()).Should().Throw<ArgumentNullException>();
+            FluentActions.Invoking(() => _testClass.PublicAddBodyStatements(new ClassModel(TestSemanticModelFactory.Class, TestSemanticModelFactory.Model, true), default(IInterfaceModel))).Should().Throw<ArgumentNullException>();
         }
     }
 }

--- a/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/EquatableGenerationStrategyTests.cs
+++ b/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/EquatableGenerationStrategyTests.cs
@@ -24,7 +24,7 @@ namespace Unitverse.Core.Tests.Strategies.InterfaceGeneration
 
             public void PublicAddBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel)
             {
-                base.AddBodyStatements(sourceModel, interfaceModel, new Core.Helpers.SectionedMethodHandler(SyntaxFactory.MethodDeclaration(SyntaxFactory.IdentifierName("string"), "id")));
+                base.AddBodyStatements(sourceModel, interfaceModel, new Core.Helpers.SectionedMethodHandler(SyntaxFactory.MethodDeclaration(SyntaxFactory.IdentifierName("string"), "id"), "Arrange", "Act", "Assert"));
             }
 
             public NameResolver PublicGeneratedMethodNamePattern => base.GeneratedMethodNamePattern;

--- a/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/InterfaceGenerationStrategyBaseTests.cs
+++ b/src/Unitverse.Core.Tests/Strategies/InterfaceGeneration/InterfaceGenerationStrategyBaseTests.cs
@@ -6,6 +6,7 @@ namespace Unitverse.Core.Tests.Strategies.InterfaceGeneration
     using NSubstitute;
     using NUnit.Framework;
     using Unitverse.Core.Frameworks;
+    using Unitverse.Core.Helpers;
     using Unitverse.Core.Models;
     using Unitverse.Core.Options;
     using Unitverse.Core.Strategies.InterfaceGeneration;
@@ -24,9 +25,8 @@ namespace Unitverse.Core.Tests.Strategies.InterfaceGeneration
 
             public NameResolver PublicGeneratedMethodNamePattern => GeneratedMethodNamePattern;
 
-            protected override IEnumerable<StatementSyntax> GetBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel)
+            protected override void AddBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel, SectionedMethodHandler method)
             {
-                yield break;
             }
 
             protected override NameResolver GeneratedMethodNamePattern { get; }

--- a/src/Unitverse.Core.Tests/TestClasses.Designer.cs
+++ b/src/Unitverse.Core.Tests/TestClasses.Designer.cs
@@ -431,6 +431,28 @@ namespace Unitverse.Core.Tests {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to // # Arrange=Set it up yo
+        ///// # Act=Do that funky thang
+        ///// # Assert=Check everything went exactly amazingly
+        ///
+        ///namespace TestNamespace.SubNameSpace
+        ///{
+        ///    public class TestClass
+        ///    {
+        ///	    public void ThisIsAMethod(string methodName, int methodValue)
+        ///	    {
+        ///		    System.Console.WriteLine(&quot;Testing this&quot;);
+        ///	    }
+        ///    }
+        ///}.
+        /// </summary>
+        public static string CommentControl {
+            get {
+                return ResourceManager.GetString("CommentControl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to namespace TestNamespace.SubNameSpace
         ///{
         ///

--- a/src/Unitverse.Core.Tests/TestClasses.resx
+++ b/src/Unitverse.Core.Tests/TestClasses.resx
@@ -157,6 +157,9 @@
   <data name="ChainedClassesTestFile" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\ChainedClassesTestFile.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="CommentControl" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\CommentControl.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="ConstrainedGenericSample" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\ConstrainedGenericSample.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/Unitverse.Core/Frameworks/FrameworkSetFactory.cs
+++ b/src/Unitverse.Core/Frameworks/FrameworkSetFactory.cs
@@ -18,7 +18,7 @@
             }
 
             var context = new GenerationContext();
-            var testFramework = Create(options.GenerationOptions.FrameworkType);
+            var testFramework = CreateTestFramework(options);
             IAssertionFramework assertionFramework = testFramework;
             return new FrameworkSet(testFramework, Create(options.GenerationOptions.MockingFrameworkType, context), options.GenerationOptions.UseFluentAssertions ? new FluentAssertionFramework(assertionFramework) : assertionFramework, new NamingProvider(options.NamingOptions), context, options.GenerationOptions.TestTypeNaming, options);
         }
@@ -38,26 +38,28 @@
             }
         }
 
-        private static ITestFramework Create(TestFrameworkTypes testFrameworkTypes)
+        private static ITestFramework CreateTestFramework(IUnitTestGeneratorOptions options)
         {
+            var testFrameworkTypes = options.GenerationOptions.FrameworkType;
+
             if ((testFrameworkTypes & TestFrameworkTypes.XUnit) > 0)
             {
-                return new XUnitTestFramework();
+                return new XUnitTestFramework(options);
             }
 
             if ((testFrameworkTypes & TestFrameworkTypes.NUnit3) > 0)
             {
-                return new NUnit3TestFramework();
+                return new NUnit3TestFramework(options);
             }
 
             if ((testFrameworkTypes & TestFrameworkTypes.NUnit2) > 0)
             {
-                return new NUnit2TestFramework();
+                return new NUnit2TestFramework(options);
             }
 
             if ((testFrameworkTypes & TestFrameworkTypes.MsTest) > 0)
             {
-                return new MsTestTestFramework();
+                return new MsTestTestFramework(options);
             }
 
             throw new NotSupportedException(Strings.FrameworkSetFactory_Create_Couldn_t_find_the_required_testing_framework);

--- a/src/Unitverse.Core/Frameworks/ITestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/ITestFramework.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Unitverse.Core.Helpers;
     using Unitverse.Core.Options;
 
     public interface ITestFramework : IAssertionFramework
@@ -14,8 +15,8 @@
 
         BaseMethodDeclarationSyntax CreateSetupMethod(string targetTypeName);
 
-        MethodDeclarationSyntax CreateTestCaseMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic, TypeSyntax valueType, IEnumerable<object> testValues);
+        SectionedMethodHandler CreateTestCaseMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic, TypeSyntax valueType, IEnumerable<object> testValues);
 
-        MethodDeclarationSyntax CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic);
+        SectionedMethodHandler CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic);
     }
 }

--- a/src/Unitverse.Core/Frameworks/Test/BaseTestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/BaseTestFramework.cs
@@ -1,0 +1,14 @@
+﻿namespace Unitverse.Core.Frameworks.Test
+{
+    using Unitverse.Core.Options;
+
+    public abstract class BaseTestFramework
+    {
+        protected BaseTestFramework(IUnitTestGeneratorOptions options)
+        {
+            Options = options;
+        }
+
+        public IUnitTestGeneratorOptions Options { get; }
+    }
+}

--- a/src/Unitverse.Core/Frameworks/Test/MsTestTestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/MsTestTestFramework.cs
@@ -8,8 +8,13 @@
     using Unitverse.Core.Options;
     using Unitverse.Core.Resources;
 
-    public class MsTestTestFramework : ITestFramework, IAssertionFramework
+    public class MsTestTestFramework : BaseTestFramework, ITestFramework, IAssertionFramework
     {
+        public MsTestTestFramework(IUnitTestGeneratorOptions options)
+            : base(options)
+        {
+        }
+
         public bool SupportsStaticTestClasses => false;
 
         public bool AssertThrowsAsyncIsAwaitable => true;
@@ -161,7 +166,7 @@
                     SyntaxFactory.SingletonSeparatedList(Generate.Attribute("TestInitialize"))));
         }
 
-        public MethodDeclarationSyntax CreateTestCaseMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic, TypeSyntax valueType, IEnumerable<object> testValues)
+        public SectionedMethodHandler CreateTestCaseMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic, TypeSyntax valueType, IEnumerable<object> testValues)
         {
             if (nameResolver is null)
             {
@@ -193,10 +198,10 @@
                 method = method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("DataRow", testValue))));
             }
 
-            return method;
+            return new SectionedMethodHandler(method);
         }
 
-        public MethodDeclarationSyntax CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic)
+        public SectionedMethodHandler CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic)
         {
             if (nameResolver is null)
             {
@@ -210,7 +215,7 @@
 
             var method = Generate.Method(nameResolver.Resolve(namingContext), isAsync, false);
 
-            return method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("TestMethod"))));
+            return new SectionedMethodHandler(method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("TestMethod")))));
         }
 
         public IEnumerable<UsingDirectiveSyntax> GetUsings()

--- a/src/Unitverse.Core/Frameworks/Test/MsTestTestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/MsTestTestFramework.cs
@@ -198,7 +198,7 @@
                 method = method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("DataRow", testValue))));
             }
 
-            return new SectionedMethodHandler(method);
+            return new SectionedMethodHandler(method, Options.GenerationOptions.ArrangeComment, Options.GenerationOptions.ActComment, Options.GenerationOptions.AssertComment);
         }
 
         public SectionedMethodHandler CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic)
@@ -213,9 +213,10 @@
                 throw new ArgumentNullException(nameof(namingContext));
             }
 
-            var method = Generate.Method(nameResolver.Resolve(namingContext), isAsync, false);
+            var method = Generate.Method(nameResolver.Resolve(namingContext), isAsync, false)
+                                 .AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("TestMethod"))));
 
-            return new SectionedMethodHandler(method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("TestMethod")))));
+            return new SectionedMethodHandler(method, Options.GenerationOptions.ArrangeComment, Options.GenerationOptions.ActComment, Options.GenerationOptions.AssertComment);
         }
 
         public IEnumerable<UsingDirectiveSyntax> GetUsings()

--- a/src/Unitverse.Core/Frameworks/Test/NUnit2TestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/NUnit2TestFramework.cs
@@ -2,9 +2,15 @@
 {
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Unitverse.Core.Helpers;
+    using Unitverse.Core.Options;
 
     public class NUnit2TestFramework : NUnitTestFramework
     {
+        public NUnit2TestFramework(IUnitTestGeneratorOptions options)
+            : base(options)
+        {
+        }
+
         public override AttributeSyntax SingleThreadedApartmentAttribute => Generate.Attribute("RequiresSTA");
     }
 }

--- a/src/Unitverse.Core/Frameworks/Test/NUnit3TestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/NUnit3TestFramework.cs
@@ -4,11 +4,17 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Unitverse.Core.Helpers;
+    using Unitverse.Core.Options;
     using Unitverse.Core.Resources;
 
     public class NUnit3TestFramework : NUnitTestFramework
     {
         private bool _requiresSystemThreading;
+
+        public NUnit3TestFramework(IUnitTestGeneratorOptions options)
+            : base(options)
+        {
+        }
 
         public override AttributeSyntax SingleThreadedApartmentAttribute
         {

--- a/src/Unitverse.Core/Frameworks/Test/NUnitTestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/NUnitTestFramework.cs
@@ -8,8 +8,13 @@
     using Unitverse.Core.Options;
     using Unitverse.Core.Resources;
 
-    public abstract class NUnitTestFramework : ITestFramework, IAssertionFramework
+    public abstract class NUnitTestFramework : BaseTestFramework, ITestFramework, IAssertionFramework
     {
+        protected NUnitTestFramework(IUnitTestGeneratorOptions options)
+            : base(options)
+        {
+        }
+
         public bool SupportsStaticTestClasses => true;
 
         public bool AssertThrowsAsyncIsAwaitable => false;
@@ -214,7 +219,7 @@
                     SyntaxFactory.SingletonSeparatedList(Generate.Attribute("SetUp"))));
         }
 
-        public MethodDeclarationSyntax CreateTestCaseMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic, TypeSyntax valueType, IEnumerable<object> testValues)
+        public SectionedMethodHandler CreateTestCaseMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic, TypeSyntax valueType, IEnumerable<object> testValues)
         {
             if (valueType == null)
             {
@@ -245,10 +250,10 @@
                 method = method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("TestCase", testValue))));
             }
 
-            return method;
+            return new SectionedMethodHandler(method);
         }
 
-        public MethodDeclarationSyntax CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic)
+        public SectionedMethodHandler CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic)
         {
             if (nameResolver is null)
             {
@@ -262,7 +267,7 @@
 
             var method = Generate.Method(nameResolver.Resolve(namingContext), isAsync, isStatic);
 
-            return method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("Test"))));
+            return new SectionedMethodHandler(method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("Test")))));
         }
 
         public virtual IEnumerable<UsingDirectiveSyntax> GetUsings()

--- a/src/Unitverse.Core/Frameworks/Test/NUnitTestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/NUnitTestFramework.cs
@@ -250,7 +250,7 @@
                 method = method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("TestCase", testValue))));
             }
 
-            return new SectionedMethodHandler(method);
+            return new SectionedMethodHandler(method, Options.GenerationOptions.ArrangeComment, Options.GenerationOptions.ActComment, Options.GenerationOptions.AssertComment);
         }
 
         public SectionedMethodHandler CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic)
@@ -265,9 +265,10 @@
                 throw new ArgumentNullException(nameof(namingContext));
             }
 
-            var method = Generate.Method(nameResolver.Resolve(namingContext), isAsync, isStatic);
+            var method = Generate.Method(nameResolver.Resolve(namingContext), isAsync, isStatic)
+                                 .AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("Test"))));
 
-            return new SectionedMethodHandler(method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("Test")))));
+            return new SectionedMethodHandler(method, Options.GenerationOptions.ArrangeComment, Options.GenerationOptions.ActComment, Options.GenerationOptions.AssertComment);
         }
 
         public virtual IEnumerable<UsingDirectiveSyntax> GetUsings()

--- a/src/Unitverse.Core/Frameworks/Test/XUnitTestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/XUnitTestFramework.cs
@@ -200,7 +200,7 @@
                 method = method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("InlineData", testValue))));
             }
 
-            return new SectionedMethodHandler(method);
+            return new SectionedMethodHandler(method, Options.GenerationOptions.ArrangeComment, Options.GenerationOptions.ActComment, Options.GenerationOptions.AssertComment);
         }
 
         public SectionedMethodHandler CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic)
@@ -215,9 +215,10 @@
                 throw new ArgumentNullException(nameof(namingContext));
             }
 
-            var method = Generate.Method(nameResolver.Resolve(namingContext), isAsync, isStatic);
+            var method = Generate.Method(nameResolver.Resolve(namingContext), isAsync, isStatic)
+                                 .AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("Fact"))));
 
-            return new SectionedMethodHandler(method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("Fact")))));
+            return new SectionedMethodHandler(method, Options.GenerationOptions.ArrangeComment, Options.GenerationOptions.ActComment, Options.GenerationOptions.AssertComment);
         }
 
         public IEnumerable<UsingDirectiveSyntax> GetUsings()

--- a/src/Unitverse.Core/Frameworks/Test/XUnitTestFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Test/XUnitTestFramework.cs
@@ -8,8 +8,13 @@
     using Unitverse.Core.Options;
     using Unitverse.Core.Resources;
 
-    public class XUnitTestFramework : ITestFramework, IAssertionFramework
+    public class XUnitTestFramework : BaseTestFramework, ITestFramework, IAssertionFramework
     {
+        public XUnitTestFramework(IUnitTestGeneratorOptions options)
+            : base(options)
+        {
+        }
+
         public bool SupportsStaticTestClasses => true;
 
         public bool AssertThrowsAsyncIsAwaitable => true;
@@ -163,7 +168,7 @@
             return SyntaxFactory.ConstructorDeclaration(SyntaxFactory.Identifier(targetTypeName)).AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
         }
 
-        public MethodDeclarationSyntax CreateTestCaseMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic, TypeSyntax valueType, IEnumerable<object> testValues)
+        public SectionedMethodHandler CreateTestCaseMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic, TypeSyntax valueType, IEnumerable<object> testValues)
         {
             if (valueType == null)
             {
@@ -195,10 +200,10 @@
                 method = method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("InlineData", testValue))));
             }
 
-            return method;
+            return new SectionedMethodHandler(method);
         }
 
-        public MethodDeclarationSyntax CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic)
+        public SectionedMethodHandler CreateTestMethod(NameResolver nameResolver, NamingContext namingContext, bool isAsync, bool isStatic)
         {
             if (nameResolver is null)
             {
@@ -212,7 +217,7 @@
 
             var method = Generate.Method(nameResolver.Resolve(namingContext), isAsync, isStatic);
 
-            return method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("Fact"))));
+            return new SectionedMethodHandler(method.AddAttributeLists(SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(Generate.Attribute("Fact")))));
         }
 
         public IEnumerable<UsingDirectiveSyntax> GetUsings()

--- a/src/Unitverse.Core/Helpers/DetectedGenerationOptions.cs
+++ b/src/Unitverse.Core/Helpers/DetectedGenerationOptions.cs
@@ -42,5 +42,11 @@
         public bool AutomaticallyConfigureMocks => _baseOptions.AutomaticallyConfigureMocks;
 
         public bool EmitSubclassForProtectedMethods => _baseOptions.EmitSubclassForProtectedMethods;
+
+        public string ArrangeComment => _baseOptions.ArrangeComment;
+
+        public string ActComment => _baseOptions.ActComment;
+
+        public string AssertComment => _baseOptions.AssertComment;
     }
 }

--- a/src/Unitverse.Core/Helpers/MockHelper.cs
+++ b/src/Unitverse.Core/Helpers/MockHelper.cs
@@ -12,30 +12,6 @@
 
     public static class MockHelper
     {
-        public static MethodDeclarationSyntax EmitStatementListWithTrivia(MethodDeclarationSyntax method, List<StatementSyntax> statements, string leadingComment, string trailingComment)
-        {
-            if (statements.Any())
-            {
-                for (int i = 0; i < statements.Count; i++)
-                {
-                    var statement = statements[i];
-                    if (i == 0 && !string.IsNullOrEmpty(leadingComment))
-                    {
-                        statement = statement.WithLeadingTrivia(SyntaxFactory.Comment(leadingComment));
-                    }
-
-                    if (i == statements.Count - 1 && !string.IsNullOrEmpty(trailingComment))
-                    {
-                        statement = statement.WithTrailingTrivia(SyntaxFactory.Comment(trailingComment));
-                    }
-
-                    method = method.AddBodyStatements(statement);
-                }
-            }
-
-            return method;
-        }
-
         public static bool PrepareMockCalls(ClassModel model, CSharpSyntaxNode targetBody, ExpressionSyntax propertyAccess, IList<ISymbol> interfaceMethodsImplemented, IEnumerable<string> parameterNames, IFrameworkSet frameworkSet, out List<StatementSyntax> mockSetupStatements, out List<StatementSyntax> mockAssertionStatements)
         {
             mockSetupStatements = new List<StatementSyntax>();

--- a/src/Unitverse.Core/Helpers/SectionedMethodHandler.cs
+++ b/src/Unitverse.Core/Helpers/SectionedMethodHandler.cs
@@ -1,0 +1,158 @@
+﻿namespace Unitverse.Core.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    public class SectionedMethodHandler
+    {
+        public SectionedMethodHandler(MethodDeclarationSyntax method)
+        {
+            Method = method ?? throw new ArgumentNullException(nameof(method));
+        }
+
+        // todo - constructor params
+        private readonly string _arrangeComment = "Arrange";
+        private readonly string _actComment = "Act";
+        private readonly string _assertComment = "Assert";
+
+        private enum Section
+        {
+            None,
+            Arrange,
+            Act,
+            Assert,
+        }
+
+        private Section _currentSection;
+
+        private bool _blankLineRequired;
+
+        private bool _anyEmitted;
+
+        public MethodDeclarationSyntax Method { get; private set; }
+
+        public void Arrange(StatementSyntax statement)
+        {
+            if (statement is null)
+            {
+                throw new ArgumentNullException(nameof(statement));
+            }
+
+            Method = Method.AddBodyStatements(Prepare(statement, Section.Arrange));
+        }
+
+        public void Arrange(IEnumerable<StatementSyntax> statements)
+        {
+            if (statements is null)
+            {
+                throw new ArgumentNullException(nameof(statements));
+            }
+
+            foreach (var statement in statements)
+            {
+                Arrange(statement);
+            }
+        }
+
+        public void Act(StatementSyntax statement)
+        {
+            if (statement is null)
+            {
+                throw new ArgumentNullException(nameof(statement));
+            }
+
+            Method = Method.AddBodyStatements(Prepare(statement, Section.Act));
+        }
+
+        public void Assert(StatementSyntax statement)
+        {
+            if (statement is null)
+            {
+                throw new ArgumentNullException(nameof(statement));
+            }
+
+            Method = Method.AddBodyStatements(Prepare(statement, Section.Assert));
+        }
+
+        public void Assert(IEnumerable<StatementSyntax> statements)
+        {
+            if (statements is null)
+            {
+                throw new ArgumentNullException(nameof(statements));
+            }
+
+            foreach (var statement in statements)
+            {
+                Assert(statement);
+            }
+        }
+
+        public void BlankLine()
+        {
+            _blankLineRequired = true;
+        }
+
+        public void Emit(StatementSyntax statement)
+        {
+            if (statement is null)
+            {
+                throw new ArgumentNullException(nameof(statement));
+            }
+
+            Method = Method.AddBodyStatements(Prepare(statement, Section.None));
+        }
+
+        public void Emit(IEnumerable<StatementSyntax> statements)
+        {
+            if (statements is null)
+            {
+                throw new ArgumentNullException(nameof(statements));
+            }
+
+            foreach (var statement in statements)
+            {
+                Emit(statement);
+            }
+        }
+
+        private StatementSyntax Prepare(StatementSyntax syntax, Section section)
+        {
+            var comment = string.Empty;
+            if (_currentSection != section)
+            {
+                switch (section)
+                {
+                    case Section.Arrange:
+                        comment = _arrangeComment;
+                        break;
+                    case Section.Act:
+                        comment = _actComment;
+                        break;
+                    case Section.Assert:
+                        comment = _assertComment;
+                        break;
+                }
+
+                _currentSection = section;
+            }
+
+            if (!string.IsNullOrEmpty(comment))
+            {
+                var prefix = _anyEmitted ? Environment.NewLine : string.Empty;
+                syntax = syntax.WithLeadingTrivia(SyntaxFactory.Comment(prefix + "// " + comment.Trim() + Environment.NewLine));
+            }
+            else if (_blankLineRequired)
+            {
+                syntax = syntax.WithLeadingTrivia(SyntaxFactory.Comment(Environment.NewLine));
+            }
+
+            _blankLineRequired = false;
+            _anyEmitted = true;
+
+            return syntax;
+        }
+    }
+}

--- a/src/Unitverse.Core/Helpers/SectionedMethodHandler.cs
+++ b/src/Unitverse.Core/Helpers/SectionedMethodHandler.cs
@@ -8,15 +8,24 @@
 
     public class SectionedMethodHandler
     {
+        // todo - remove
         public SectionedMethodHandler(MethodDeclarationSyntax method)
+            : this(method, "Arrange", "Act", "Assert")
         {
-            Method = method ?? throw new ArgumentNullException(nameof(method));
         }
 
-        // todo - constructor params
-        private readonly string _arrangeComment = "Arrange";
-        private readonly string _actComment = "Act";
-        private readonly string _assertComment = "Assert";
+
+        public SectionedMethodHandler(MethodDeclarationSyntax method, string arrangeComment, string actComment, string assertComment)
+        {
+            Method = method ?? throw new ArgumentNullException(nameof(method));
+            _arrangeComment = arrangeComment;
+            _actComment = actComment;
+            _assertComment = assertComment;
+        }
+
+        private readonly string _arrangeComment;
+        private readonly string _actComment;
+        private readonly string _assertComment;
 
         private enum Section
         {
@@ -127,12 +136,15 @@
                 {
                     case Section.Arrange:
                         comment = _arrangeComment;
+                        _blankLineRequired = _anyEmitted;
                         break;
                     case Section.Act:
                         comment = _actComment;
+                        _blankLineRequired = _anyEmitted;
                         break;
                     case Section.Assert:
                         comment = _assertComment;
+                        _blankLineRequired = _anyEmitted;
                         break;
                 }
 

--- a/src/Unitverse.Core/Helpers/SectionedMethodHandler.cs
+++ b/src/Unitverse.Core/Helpers/SectionedMethodHandler.cs
@@ -8,13 +8,6 @@
 
     public class SectionedMethodHandler
     {
-        // todo - remove
-        public SectionedMethodHandler(MethodDeclarationSyntax method)
-            : this(method, "Arrange", "Act", "Assert")
-        {
-        }
-
-
         public SectionedMethodHandler(MethodDeclarationSyntax method, string arrangeComment, string actComment, string assertComment)
         {
             Method = method ?? throw new ArgumentNullException(nameof(method));
@@ -151,10 +144,17 @@
                 _currentSection = section;
             }
 
-            if (!string.IsNullOrEmpty(comment))
+            if (!string.IsNullOrWhiteSpace(comment))
             {
-                var prefix = _anyEmitted ? Environment.NewLine : string.Empty;
-                syntax = syntax.WithLeadingTrivia(SyntaxFactory.Comment(prefix + "// " + comment.Trim() + Environment.NewLine));
+                var commentSyntax = SyntaxFactory.Comment("// " + comment.Trim() + Environment.NewLine);
+                if (_anyEmitted)
+                {
+                    syntax = syntax.WithLeadingTrivia(SyntaxFactory.Comment(Environment.NewLine), commentSyntax);
+                }
+                else
+                {
+                    syntax = syntax.WithLeadingTrivia(commentSyntax);
+                }
             }
             else if (_blankLineRequired)
             {

--- a/src/Unitverse.Core/Options/IGenerationOptions.cs
+++ b/src/Unitverse.Core/Options/IGenerationOptions.cs
@@ -27,5 +27,11 @@
         bool EmitSubclassForProtectedMethods { get; }
 
         bool AutomaticallyConfigureMocks { get; }
+
+        string ArrangeComment { get; }
+
+        string ActComment { get; }
+
+        string AssertComment { get; }
     }
 }

--- a/src/Unitverse.Core/Options/MutableGenerationOptions.cs
+++ b/src/Unitverse.Core/Options/MutableGenerationOptions.cs
@@ -24,6 +24,9 @@
             EmitTestsForInternals = options.EmitTestsForInternals;
             AutomaticallyConfigureMocks = options.AutomaticallyConfigureMocks;
             EmitSubclassForProtectedMethods = options.EmitSubclassForProtectedMethods;
+            ArrangeComment = options.ArrangeComment;
+            ActComment = options.ActComment;
+            AssertComment = options.AssertComment;
         }
 
         public TestFrameworkTypes FrameworkType { get; set; }
@@ -51,5 +54,11 @@
         public bool EmitSubclassForProtectedMethods { get; set; }
 
         public bool AutomaticallyConfigureMocks { get; set; }
+
+        public string ArrangeComment { get; set; }
+
+        public string ActComment { get; set; }
+
+        public string AssertComment { get; set; }
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructMultiConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructMultiConstructorGenerationStrategy.cs
@@ -65,18 +65,19 @@
 
                 if (isFirst)
                 {
-                    generatedMethod = generatedMethod.AddBodyStatements(Generate.ImplicitlyTypedVariableDeclaration("instance", creationExpression));
+                    generatedMethod.Act(Generate.ImplicitlyTypedVariableDeclaration("instance", creationExpression));
                     isFirst = false;
                 }
                 else
                 {
-                    generatedMethod = generatedMethod.AddBodyStatements(SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.IdentifierName("instance"), creationExpression)));
+                    generatedMethod.Act(SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.IdentifierName("instance"), creationExpression)));
                 }
 
-                generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
+                generatedMethod.Assert(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
+                generatedMethod.BlankLine();
             }
 
-            yield return generatedMethod;
+            yield return generatedMethod.Method;
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructNoConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructNoConstructorGenerationStrategy.cs
@@ -55,11 +55,11 @@
 
             var generatedMethod = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanConstruct, namingContext, false, false);
 
-            generatedMethod = generatedMethod.AddBodyStatements(Generate.ImplicitlyTypedVariableDeclaration("instance", Generate.ObjectCreation(model.TypeSyntax)));
+            generatedMethod.Act(Generate.ImplicitlyTypedVariableDeclaration("instance", Generate.ObjectCreation(model.TypeSyntax)));
 
-            generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
+            generatedMethod.Assert(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
 
-            yield return generatedMethod;
+            yield return generatedMethod.Method;
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructSingleConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructSingleConstructorGenerationStrategy.cs
@@ -65,11 +65,11 @@
 
             var generatedMethod = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanConstruct, namingContext, false, false);
 
-            generatedMethod = generatedMethod.AddBodyStatements(Generate.ImplicitlyTypedVariableDeclaration("instance", model.GetObjectCreationExpression(_frameworkSet)));
+            generatedMethod.Act(Generate.ImplicitlyTypedVariableDeclaration("instance", model.GetObjectCreationExpression(_frameworkSet)));
 
-            generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
+            generatedMethod.Assert(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
 
-            yield return generatedMethod;
+            yield return generatedMethod.Method;
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanInitializeGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanInitializeGenerationStrategy.cs
@@ -60,11 +60,11 @@
 
             var generatedMethod = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanInitialize, namingContext, false, false);
 
-            generatedMethod = generatedMethod.AddBodyStatements(Generate.ImplicitlyTypedVariableDeclaration("instance", model.GetObjectCreationExpression(_frameworkSet)));
+            generatedMethod.Act(Generate.ImplicitlyTypedVariableDeclaration("instance", model.GetObjectCreationExpression(_frameworkSet)));
 
-            generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
+            generatedMethod.Assert(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
 
-            yield return generatedMethod;
+            yield return generatedMethod.Method;
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullParameterCheckConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullParameterCheckConstructorGenerationStrategy.cs
@@ -84,10 +84,10 @@
 
                     var paramExpressions = constructorModel.Parameters.Select(param => string.Equals(param.Name, nullableParameter, StringComparison.OrdinalIgnoreCase) ? SyntaxFactory.DefaultExpression(param.TypeInfo.ToTypeSyntax(_frameworkSet.Context)) : AssignmentValueHelper.GetDefaultAssignmentValue(param.TypeInfo, model.SemanticModel, _frameworkSet)).ToList();
                     var methodCall = Generate.ObjectCreation(model.TypeSyntax, paramExpressions.ToArray());
-                    generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+                    generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
                 }
 
-                yield return generatedMethod;
+                yield return generatedMethod.Method;
             }
         }
     }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullPropertyCheckInitializerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/NullPropertyCheckInitializerGenerationStrategy.cs
@@ -82,9 +82,9 @@
                 }
 
                 var methodCall = Generate.ObjectCreation(model.TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetAssignedValue(x))));
-                generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+                generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
 
-                yield return generatedMethod;
+                yield return generatedMethod.Method;
             }
         }
     }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringParameterCheckConstructorGenerationStrategy.cs
@@ -72,10 +72,10 @@
                 {
                     var paramExpressions = constructorModel.Parameters.Select(param => string.Equals(param.Name, nullableParameter, StringComparison.OrdinalIgnoreCase) ? SyntaxFactory.IdentifierName("value") : AssignmentValueHelper.GetDefaultAssignmentValue(param.TypeInfo, model.SemanticModel, _frameworkSet)).ToList();
                     var methodCall = Generate.ObjectCreation(model.TypeSyntax, paramExpressions.ToArray());
-                    generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+                    generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
                 }
 
-                yield return generatedMethod;
+                yield return generatedMethod.Method;
             }
         }
     }

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringPropertyCheckInitializerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/StringPropertyCheckInitializerGenerationStrategy.cs
@@ -79,9 +79,9 @@
                 }
 
                 var methodCall = Generate.ObjectCreation(model.TypeSyntax, initializableProperties.Select(x => Generate.Assignment(x.Name, GetAssignedValue(x))));
-                generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+                generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
 
-                yield return generatedMethod;
+                yield return generatedMethod.Method;
             }
         }
     }

--- a/src/Unitverse.Core/Strategies/IndexerGeneration/ReadOnlyIndexerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/IndexerGeneration/ReadOnlyIndexerGenerationStrategy.cs
@@ -55,11 +55,12 @@
 
             var paramExpressions = indexer.Parameters.Select(param => AssignmentValueHelper.GetDefaultAssignmentValue(param.TypeInfo, model.SemanticModel, _frameworkSet)).ToArray();
 
-            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanGet, namingContext, false, model.IsStatic)
-                .AddBodyStatements(_frameworkSet.AssertionFramework.AssertIsInstanceOf(Generate.IndexerAccess(model.TargetInstance, paramExpressions), indexer.TypeInfo.ToTypeSyntax(_frameworkSet.Context), indexer.TypeInfo.Type.IsReferenceType))
-                .AddBodyStatements(_frameworkSet.AssertionFramework.AssertFail(Strings.PlaceholderAssertionMessage));
+            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanGet, namingContext, false, model.IsStatic);
 
-            yield return method;
+            method.Emit(_frameworkSet.AssertionFramework.AssertIsInstanceOf(Generate.IndexerAccess(model.TargetInstance, paramExpressions), indexer.TypeInfo.ToTypeSyntax(_frameworkSet.Context), indexer.TypeInfo.Type.IsReferenceType));
+            method.Emit(_frameworkSet.AssertionFramework.AssertFail(Strings.PlaceholderAssertionMessage));
+
+            yield return method.Method;
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/IndexerGeneration/ReadWriteIndexerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/IndexerGeneration/ReadWriteIndexerGenerationStrategy.cs
@@ -53,10 +53,10 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanSetAndGet, namingContext, false, model.IsStatic)
-                .AddBodyStatements(GetPropertyAssertionBodyStatements(indexer, model).ToArray());
+            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanSetAndGet, namingContext, false, model.IsStatic);
+            method.Emit(GetPropertyAssertionBodyStatements(indexer, model).ToArray());
 
-            yield return method;
+            yield return method.Method;
         }
 
         private IEnumerable<StatementSyntax> GetPropertyAssertionBodyStatements(IIndexerModel indexer, ClassModel sourceModel)

--- a/src/Unitverse.Core/Strategies/IndexerGeneration/WriteOnlyIndexerGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/IndexerGeneration/WriteOnlyIndexerGenerationStrategy.cs
@@ -53,10 +53,10 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanSet, namingContext, false, model.IsStatic)
-                .AddBodyStatements(GetPropertyAssertionBodyStatements(indexer, model).ToArray());
+            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanSet, namingContext, false, model.IsStatic);
+            method.Emit(GetPropertyAssertionBodyStatements(indexer, model).ToArray());
 
-            yield return method;
+            yield return method.Method;
         }
 
         private IEnumerable<StatementSyntax> GetPropertyAssertionBodyStatements(IIndexerModel indexer, ClassModel sourceModel)

--- a/src/Unitverse.Core/Strategies/InterfaceGeneration/ComparableGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/InterfaceGeneration/ComparableGenerationStrategy.cs
@@ -23,7 +23,7 @@
 
         protected override NameResolver GeneratedMethodNamePattern => FrameworkSet.NamingProvider.ImplementsIComparable;
 
-        protected override IEnumerable<StatementSyntax> GetBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel)
+        protected override void AddBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel, SectionedMethodHandler method)
         {
             ITypeSymbol comparableTypeIdentifier = sourceModel.TypeSymbol;
             if (interfaceModel.IsGeneric)
@@ -33,29 +33,29 @@
 
             var typeSyntax = comparableTypeIdentifier.ToTypeSyntax(FrameworkSet.Context);
 
-            yield return SyntaxHelper.CreateVariableDeclaration(
+            method.Arrange(SyntaxHelper.CreateVariableDeclaration(
                     sourceModel.TypeSymbol.ToTypeSyntax(FrameworkSet.Context),
                     "baseValue",
                     SyntaxFactory.DefaultExpression(sourceModel.TypeSyntax))
-                .AsLocalVariableDeclarationStatementSyntax();
+                .AsLocalVariableDeclarationStatementSyntax());
 
-            yield return SyntaxHelper.CreateVariableDeclaration(
+            method.Arrange(SyntaxHelper.CreateVariableDeclaration(
                     typeSyntax,
                     "equalToBaseValue",
                     SyntaxFactory.DefaultExpression(typeSyntax))
-                .AsLocalVariableDeclarationStatementSyntax();
+                .AsLocalVariableDeclarationStatementSyntax());
 
-            yield return SyntaxHelper.CreateVariableDeclaration(
+            method.Arrange(SyntaxHelper.CreateVariableDeclaration(
                     typeSyntax,
                     "greaterThanBaseValue",
                     SyntaxFactory.DefaultExpression(typeSyntax))
-                .AsLocalVariableDeclarationStatementSyntax();
+                .AsLocalVariableDeclarationStatementSyntax());
 
-            yield return FrameworkSet.AssertionFramework.AssertEqual(CreateInvocationStatement("baseValue", "CompareTo", "equalToBaseValue"), Generate.Literal(0), false);
+            method.Assert(FrameworkSet.AssertionFramework.AssertEqual(CreateInvocationStatement("baseValue", "CompareTo", "equalToBaseValue"), Generate.Literal(0), false));
 
-            yield return FrameworkSet.AssertionFramework.AssertLessThan(CreateInvocationStatement("baseValue", "CompareTo", "greaterThanBaseValue"), Generate.Literal(0));
+            method.Assert(FrameworkSet.AssertionFramework.AssertLessThan(CreateInvocationStatement("baseValue", "CompareTo", "greaterThanBaseValue"), Generate.Literal(0)));
 
-            yield return FrameworkSet.AssertionFramework.AssertGreaterThan(CreateInvocationStatement("greaterThanBaseValue", "CompareTo", "baseValue"), Generate.Literal(0));
+            method.Assert(FrameworkSet.AssertionFramework.AssertGreaterThan(CreateInvocationStatement("greaterThanBaseValue", "CompareTo", "baseValue"), Generate.Literal(0)));
         }
 
         private static InvocationExpressionSyntax CreateInvocationStatement(string targetName, string memberName, string parameterName)

--- a/src/Unitverse.Core/Strategies/InterfaceGeneration/EnumerableGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/InterfaceGeneration/EnumerableGenerationStrategy.cs
@@ -23,7 +23,7 @@
 
         protected override NameResolver GeneratedMethodNamePattern => FrameworkSet.NamingProvider.ImplementsIEnumerable;
 
-        protected override IEnumerable<StatementSyntax> GetBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel)
+        protected override void AddBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel, SectionedMethodHandler method)
         {
             ITypeSymbol enumerableTypeSymbol = sourceModel.TypeSymbol;
             if (interfaceModel.IsGeneric)
@@ -32,25 +32,25 @@
                 enumerableTypeSymbol = interfaceModel.GenericTypes.First();
             }
 
-            yield return SyntaxHelper.CreateVariableDeclaration(
+            method.Arrange(SyntaxHelper.CreateVariableDeclaration(
                 sourceModel.TypeSymbol.ToTypeSyntax(FrameworkSet.Context),
                 "enumerable",
                 SyntaxFactory.DefaultExpression(sourceModel.TypeSyntax))
-                .AsLocalVariableDeclarationStatementSyntax();
+                .AsLocalVariableDeclarationStatementSyntax());
 
-            yield return SyntaxHelper.CreateVariableDeclaration(
+            method.Arrange(SyntaxHelper.CreateVariableDeclaration(
                 SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)),
                 "expectedCount",
                 SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(-1)))
-                .AsLocalVariableDeclarationStatementSyntax();
+                .AsLocalVariableDeclarationStatementSyntax());
 
-            yield return SyntaxHelper.CreateVariableDeclaration(
+            method.Arrange(SyntaxHelper.CreateVariableDeclaration(
                 SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)),
                 "actualCount",
                 SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(0)))
-                .AsLocalVariableDeclarationStatementSyntax();
+                .AsLocalVariableDeclarationStatementSyntax());
 
-            yield return SyntaxFactory.UsingStatement(
+            method.Act(SyntaxFactory.UsingStatement(
                 SyntaxFactory.Block(
                     FrameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("enumerator")),
                     SyntaxFactory.WhileStatement(
@@ -76,9 +76,9 @@
                         SyntaxFactory.MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             SyntaxFactory.IdentifierName("enumerable"),
-                            SyntaxFactory.IdentifierName("GetEnumerator")))));
+                            SyntaxFactory.IdentifierName("GetEnumerator"))))));
 
-            yield return FrameworkSet.AssertionFramework.AssertEqual(SyntaxFactory.IdentifierName("actualCount"), SyntaxFactory.IdentifierName("expectedCount"), false);
+            method.Assert(FrameworkSet.AssertionFramework.AssertEqual(SyntaxFactory.IdentifierName("actualCount"), SyntaxFactory.IdentifierName("expectedCount"), false));
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/InterfaceGeneration/EquatableGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/InterfaceGeneration/EquatableGenerationStrategy.cs
@@ -24,7 +24,7 @@
 
         protected override NameResolver GeneratedMethodNamePattern => FrameworkSet.NamingProvider.ImplementsIEquatable;
 
-        protected override IEnumerable<StatementSyntax> GetBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel)
+        protected override void AddBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel, SectionedMethodHandler method)
         {
             if (sourceModel is null)
             {
@@ -49,30 +49,30 @@
                 sameExpression = AssignmentValueHelper.GetDefaultAssignmentValue(equatableTypeSymbol, sourceModel.SemanticModel, FrameworkSet);
             }
 
-            yield return Generate.VariableDeclaration(equatableTypeSymbol, FrameworkSet, "same", sameExpression);
-            yield return Generate.VariableDeclaration(equatableTypeSymbol, FrameworkSet, "different", differentExpression);
+            method.Arrange(Generate.VariableDeclaration(equatableTypeSymbol, FrameworkSet, "same", sameExpression));
+            method.Arrange(Generate.VariableDeclaration(equatableTypeSymbol, FrameworkSet, "different", differentExpression));
 
             var same = SyntaxFactory.IdentifierName("same");
             var different = SyntaxFactory.IdentifierName("different");
 
             var objType = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword));
 
-            yield return FrameworkSet.AssertionFramework.AssertFalse(Generate.Invocation(sourceModel.TargetInstance, "Equals", SyntaxFactory.DefaultExpression(objType)));
-            yield return FrameworkSet.AssertionFramework.AssertFalse(Generate.Invocation(sourceModel.TargetInstance, "Equals", SyntaxFactory.ObjectCreationExpression(objType).WithArgumentList(SyntaxFactory.ArgumentList())));
-            yield return FrameworkSet.AssertionFramework.AssertTrue(Generate.Invocation(sourceModel.TargetInstance, "Equals", SyntaxFactory.CastExpression(objType, same)));
-            yield return FrameworkSet.AssertionFramework.AssertFalse(Generate.Invocation(sourceModel.TargetInstance, "Equals", SyntaxFactory.CastExpression(objType, different)));
+            method.Assert(FrameworkSet.AssertionFramework.AssertFalse(Generate.Invocation(sourceModel.TargetInstance, "Equals", SyntaxFactory.DefaultExpression(objType))));
+            method.Assert(FrameworkSet.AssertionFramework.AssertFalse(Generate.Invocation(sourceModel.TargetInstance, "Equals", SyntaxFactory.ObjectCreationExpression(objType).WithArgumentList(SyntaxFactory.ArgumentList()))));
+            method.Assert(FrameworkSet.AssertionFramework.AssertTrue(Generate.Invocation(sourceModel.TargetInstance, "Equals", SyntaxFactory.CastExpression(objType, same))));
+            method.Assert(FrameworkSet.AssertionFramework.AssertFalse(Generate.Invocation(sourceModel.TargetInstance, "Equals", SyntaxFactory.CastExpression(objType, different))));
 
-            yield return FrameworkSet.AssertionFramework.AssertTrue(Generate.Invocation(sourceModel.TargetInstance, "Equals", same));
-            yield return FrameworkSet.AssertionFramework.AssertFalse(Generate.Invocation(sourceModel.TargetInstance, "Equals", different));
+            method.Assert(FrameworkSet.AssertionFramework.AssertTrue(Generate.Invocation(sourceModel.TargetInstance, "Equals", same)));
+            method.Assert(FrameworkSet.AssertionFramework.AssertFalse(Generate.Invocation(sourceModel.TargetInstance, "Equals", different)));
 
-            yield return FrameworkSet.AssertionFramework.AssertEqual(Generate.Invocation(sourceModel.TargetInstance, "GetHashCode"), Generate.Invocation(same, "GetHashCode"), false);
-            yield return FrameworkSet.AssertionFramework.AssertNotEqual(Generate.Invocation(sourceModel.TargetInstance, "GetHashCode"), Generate.Invocation(different, "GetHashCode"), false);
+            method.Assert(FrameworkSet.AssertionFramework.AssertEqual(Generate.Invocation(sourceModel.TargetInstance, "GetHashCode"), Generate.Invocation(same, "GetHashCode"), false));
+            method.Assert(FrameworkSet.AssertionFramework.AssertNotEqual(Generate.Invocation(sourceModel.TargetInstance, "GetHashCode"), Generate.Invocation(different, "GetHashCode"), false));
 
-            yield return FrameworkSet.AssertionFramework.AssertTrue(SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, sourceModel.TargetInstance, same));
-            yield return FrameworkSet.AssertionFramework.AssertFalse(SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, sourceModel.TargetInstance, different));
+            method.Assert(FrameworkSet.AssertionFramework.AssertTrue(SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, sourceModel.TargetInstance, same)));
+            method.Assert(FrameworkSet.AssertionFramework.AssertFalse(SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, sourceModel.TargetInstance, different)));
 
-            yield return FrameworkSet.AssertionFramework.AssertFalse(SyntaxFactory.BinaryExpression(SyntaxKind.NotEqualsExpression, sourceModel.TargetInstance, same));
-            yield return FrameworkSet.AssertionFramework.AssertTrue(SyntaxFactory.BinaryExpression(SyntaxKind.NotEqualsExpression, sourceModel.TargetInstance, different));
+            method.Assert(FrameworkSet.AssertionFramework.AssertFalse(SyntaxFactory.BinaryExpression(SyntaxKind.NotEqualsExpression, sourceModel.TargetInstance, same)));
+            method.Assert(FrameworkSet.AssertionFramework.AssertTrue(SyntaxFactory.BinaryExpression(SyntaxKind.NotEqualsExpression, sourceModel.TargetInstance, different)));
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/InterfaceGeneration/InterfaceGenerationStrategyBase.cs
+++ b/src/Unitverse.Core/Strategies/InterfaceGeneration/InterfaceGenerationStrategyBase.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Unitverse.Core.Frameworks;
+    using Unitverse.Core.Helpers;
     using Unitverse.Core.Models;
     using Unitverse.Core.Options;
 
@@ -65,11 +66,11 @@
                 namingContext = namingContext.WithInterfaceName(interfaceModel.InterfaceName).WithTypeParameters(typeParameters);
 
                 var method = FrameworkSet.TestFramework.CreateTestMethod(GeneratedMethodNamePattern, namingContext, false, model != null && model.IsStatic);
-                var body = GetBodyStatements(classModel, interfaceModel);
-                yield return method.AddBodyStatements(body.ToArray());
+                AddBodyStatements(classModel, interfaceModel, method);
+                yield return method.Method;
             }
         }
 
-        protected abstract IEnumerable<StatementSyntax> GetBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel);
+        protected abstract void AddBodyStatements(ClassModel sourceModel, IInterfaceModel interfaceModel, SectionedMethodHandler method);
     }
 }

--- a/src/Unitverse.Core/Strategies/MethodGeneration/MappingMethodGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/MethodGeneration/MappingMethodGenerationStrategy.cs
@@ -117,7 +117,7 @@
                 {
                     var defaultAssignmentValue = AssignmentValueHelper.GetDefaultAssignmentValue(parameter.TypeInfo, model.SemanticModel, _frameworkSet);
 
-                    generatedMethod = generatedMethod.AddBodyStatements(Generate.VariableDeclaration(parameter.TypeInfo.Type, _frameworkSet, parameter.Name, defaultAssignmentValue));
+                    generatedMethod.Arrange(Generate.VariableDeclaration(parameter.TypeInfo.Type, _frameworkSet, parameter.Name, defaultAssignmentValue));
 
                     if (parameter.Node.Modifiers.Any(x => x.Kind() == SyntaxKind.RefKeyword))
                     {
@@ -156,7 +156,7 @@
                 bodyStatement = SyntaxFactory.ExpressionStatement(methodCall);
             }
 
-            generatedMethod = generatedMethod.AddBodyStatements(bodyStatement);
+            generatedMethod.Act(bodyStatement);
 
             var returnTypeInfo = model.SemanticModel.GetTypeInfo(method.Node.ReturnType).Type;
             if (returnTypeInfo == null || returnTypeInfo.SpecialType != SpecialType.None || method.Node.IsKind(SyntaxKind.IndexerDeclaration) || (returnTypeInfo.ToFullName() == typeof(Task).FullName && !(returnTypeInfo is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.IsGenericType)))
@@ -177,7 +177,7 @@
                 {
                     var returnTypeMember = returnTypeMembers.FirstOrDefault(x => string.Equals(x.Key, methodParameter.Name, StringComparison.OrdinalIgnoreCase));
                     var resultProperty = Generate.PropertyAccess(SyntaxFactory.IdentifierName("result"), returnTypeMember.Key);
-                    generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertEqual(resultProperty, SyntaxFactory.IdentifierName(methodParameter.Name), returnTypeMembers[methodParameter.Name]));
+                    generatedMethod.Assert(_frameworkSet.AssertionFramework.AssertEqual(resultProperty, SyntaxFactory.IdentifierName(methodParameter.Name), returnTypeMembers[methodParameter.Name]));
                     continue;
                 }
 
@@ -188,12 +188,12 @@
                     {
                         var returnTypeMember = returnTypeMembers.FirstOrDefault(x => string.Equals(x.Key, matchedSourceProperty.Key, StringComparison.OrdinalIgnoreCase));
                         var resultProperty = Generate.PropertyAccess(SyntaxFactory.IdentifierName("result"), returnTypeMember.Key);
-                        generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertEqual(resultProperty,  Generate.PropertyAccess(SyntaxFactory.IdentifierName(methodParameter.Name), matchedSourceProperty.Key), matchedSourceProperty.Value));
+                        generatedMethod.Assert(_frameworkSet.AssertionFramework.AssertEqual(resultProperty,  Generate.PropertyAccess(SyntaxFactory.IdentifierName(methodParameter.Name), matchedSourceProperty.Key), matchedSourceProperty.Value));
                     }
                 }
             }
 
-            yield return generatedMethod;
+            yield return generatedMethod.Method;
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/MethodGeneration/NullParameterCheckMethodGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/MethodGeneration/NullParameterCheckMethodGenerationStrategy.cs
@@ -92,7 +92,7 @@
                             defaultAssignmentValue = SyntaxFactory.DefaultExpression(method.Parameters[i].TypeInfo.ToTypeSyntax(_frameworkSet.Context));
                         }
 
-                        generatedMethod = generatedMethod.AddBodyStatements(Generate.VariableDeclaration(parameter.TypeInfo.Type, _frameworkSet, parameter.Name, defaultAssignmentValue));
+                        generatedMethod.Emit(Generate.VariableDeclaration(parameter.TypeInfo.Type, _frameworkSet, parameter.Name, defaultAssignmentValue));
 
                         paramList.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(parameter.Name)).WithRefKindKeyword(SyntaxFactory.Token(SyntaxKind.RefKeyword)));
                     }
@@ -117,14 +117,14 @@
 
                 if (method.IsAsync)
                 {
-                    generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrowsAsync(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+                    generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrowsAsync(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
                 }
                 else
                 {
-                    generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+                    generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
                 }
 
-                yield return generatedMethod;
+                yield return generatedMethod.Method;
             }
         }
     }

--- a/src/Unitverse.Core/Strategies/MethodGeneration/StringParameterCheckMethodGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/MethodGeneration/StringParameterCheckMethodGenerationStrategy.cs
@@ -87,7 +87,7 @@
                             defaultAssignmentValue = SyntaxFactory.DefaultExpression(method.Parameters[i].TypeInfo.ToTypeSyntax(_frameworkSet.Context));
                         }
 
-                        generatedMethod = generatedMethod.AddBodyStatements(Generate.VariableDeclaration(parameter.TypeInfo.Type, _frameworkSet, parameter.Name, defaultAssignmentValue));
+                        generatedMethod.Emit(Generate.VariableDeclaration(parameter.TypeInfo.Type, _frameworkSet, parameter.Name, defaultAssignmentValue));
 
                         paramList.Add(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(parameter.Name)).WithRefKindKeyword(SyntaxFactory.Token(SyntaxKind.RefKeyword)));
                     }
@@ -112,14 +112,14 @@
 
                 if (method.IsAsync)
                 {
-                    generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrowsAsync(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+                    generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrowsAsync(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
                 }
                 else
                 {
-                    generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
+                    generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), methodCall));
                 }
 
-                yield return generatedMethod;
+                yield return generatedMethod.Method;
             }
         }
     }

--- a/src/Unitverse.Core/Strategies/OperatorGeneration/CanCallOperatorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/OperatorGeneration/CanCallOperatorGenerationStrategy.cs
@@ -60,7 +60,7 @@
             {
                 var defaultAssignmentValue = AssignmentValueHelper.GetDefaultAssignmentValue(parameter.TypeInfo, model.SemanticModel, _frameworkSet);
 
-                generatedMethod = generatedMethod.AddBodyStatements(Generate.VariableDeclaration(parameter.TypeInfo.Type, _frameworkSet, parameter.Name, defaultAssignmentValue));
+                generatedMethod.Arrange(Generate.VariableDeclaration(parameter.TypeInfo.Type, _frameworkSet, parameter.Name, defaultAssignmentValue));
 
                 paramExpressions.Add(SyntaxFactory.IdentifierName(parameter.Name));
             }
@@ -69,11 +69,11 @@
 
             var bodyStatement = Generate.ImplicitlyTypedVariableDeclaration("result", methodCall);
 
-            generatedMethod = generatedMethod.AddBodyStatements(bodyStatement);
+            generatedMethod.Act(bodyStatement);
 
-            generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertFail(Strings.PlaceholderAssertionMessage));
+            generatedMethod.Assert(_frameworkSet.AssertionFramework.AssertFail(Strings.PlaceholderAssertionMessage));
 
-            yield return generatedMethod;
+            yield return generatedMethod.Method;
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/OperatorGeneration/NullParameterCheckOperatorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/OperatorGeneration/NullParameterCheckOperatorGenerationStrategy.cs
@@ -92,9 +92,9 @@
                         SyntaxFactory.SingletonList<StatementSyntax>(
                             Generate.ImplicitlyTypedVariableDeclaration("result", methodCall))));
 
-                generatedMethod = generatedMethod.AddBodyStatements(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), assignment));
+                generatedMethod.Emit(_frameworkSet.AssertionFramework.AssertThrows(SyntaxFactory.IdentifierName("ArgumentNullException"), assignment));
 
-                yield return generatedMethod;
+                yield return generatedMethod.Method;
             }
         }
     }

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/MultiConstructorInitializedPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/MultiConstructorInitializedPropertyGenerationStrategy.cs
@@ -68,10 +68,10 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.IsInitializedCorrectly, namingContext, false, model.IsStatic)
-                .AddBodyStatements(GetPropertyAssertionBodyStatements(property, model).ToArray());
+            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.IsInitializedCorrectly, namingContext, false, model.IsStatic);
+            method.Emit(GetPropertyAssertionBodyStatements(property, model).ToArray());
 
-            yield return method;
+            yield return method.Method;
         }
 
         private IEnumerable<StatementSyntax> GetPropertyAssertionBodyStatements(IPropertyModel property, ClassModel model)

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/NotifyPropertyChangedGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/NotifyPropertyChangedGenerationStrategy.cs
@@ -60,10 +60,10 @@
 
             model.RequiredAssets.Add(TargetAsset.PropertyTester);
 
-            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanSetAndGet, namingContext, false, model.IsStatic)
-                .AddBodyStatements(GetPropertyAssertionBodyStatements(property, model, withDefaults).ToArray());
+            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanSetAndGet, namingContext, false, model.IsStatic);
+            method.Emit(GetPropertyAssertionBodyStatements(property, model, withDefaults).ToArray());
 
-            yield return method;
+            yield return method.Method;
         }
 
         private IEnumerable<StatementSyntax> GetPropertyAssertionBodyStatements(IPropertyModel property, ClassModel sourceModel, bool withDefaults)

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/ReadOnlyPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/ReadOnlyPropertyGenerationStrategy.cs
@@ -84,7 +84,7 @@
 
             if (!testIsComplete)
             {
-                method.Arrange(_frameworkSet.AssertionFramework.AssertFail(Strings.PlaceholderAssertionMessage));
+                method.Assert(_frameworkSet.AssertionFramework.AssertFail(Strings.PlaceholderAssertionMessage));
             }
 
             yield return method.Method;

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/ReadOnlyPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/ReadOnlyPropertyGenerationStrategy.cs
@@ -68,27 +68,26 @@
 
             var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanGet, namingContext, false, model.IsStatic);
 
-            method = MockHelper.EmitStatementListWithTrivia(method, mockSetupStatements, null, testIsComplete ? string.Empty : Environment.NewLine + Environment.NewLine);
+            method.Arrange(mockSetupStatements);
+            method.BlankLine();
 
             if (!testIsComplete)
             {
                 var bodyStatement = _frameworkSet.AssertionFramework.AssertIsInstanceOf(property.Access(target), property.TypeInfo.ToTypeSyntax(_frameworkSet.Context), property.TypeInfo.Type.IsReferenceType);
-                if (mockAssertionStatements.Count > 0)
-                {
-                    bodyStatement = bodyStatement.WithTrailingTrivia(SyntaxFactory.Comment(Environment.NewLine + Environment.NewLine));
-                }
 
-                method = method.AddBodyStatements(bodyStatement);
+                method.Assert(bodyStatement);
+                method.BlankLine();
             }
 
-            method = MockHelper.EmitStatementListWithTrivia(method, mockAssertionStatements, null, testIsComplete ? string.Empty : Environment.NewLine + Environment.NewLine);
+            method.Assert(mockAssertionStatements);
+            method.BlankLine();
 
             if (!testIsComplete)
             {
-                method = method.AddBodyStatements(_frameworkSet.AssertionFramework.AssertFail(Strings.PlaceholderAssertionMessage));
+                method.Arrange(_frameworkSet.AssertionFramework.AssertFail(Strings.PlaceholderAssertionMessage));
             }
 
-            yield return method;
+            yield return method.Method;
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/ReadWritePropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/ReadWritePropertyGenerationStrategy.cs
@@ -61,26 +61,24 @@
 
             var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanSetAndGet, namingContext, false, model.IsStatic);
 
-            method = MockHelper.EmitStatementListWithTrivia(method, mockSetupStatements, null, Environment.NewLine + Environment.NewLine);
+            method.Arrange(mockSetupStatements);
+            method.BlankLine();
 
             var defaultValue = AssignmentValueHelper.GetDefaultAssignmentValue(property.TypeInfo, model.SemanticModel, _frameworkSet);
             var declareTestValue = Generate.VariableDeclaration(property.TypeInfo.Type, _frameworkSet, "testValue", defaultValue);
 
-            method = method.AddBodyStatements(declareTestValue);
+            method.Arrange(declareTestValue);
 
-            method = method.AddBodyStatements(SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, property.Access(target), SyntaxFactory.IdentifierName("testValue"))));
+            method.Act(SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, property.Access(target), SyntaxFactory.IdentifierName("testValue"))));
 
             var bodyStatement = _frameworkSet.AssertionFramework.AssertEqual(property.Access(target), SyntaxFactory.IdentifierName("testValue"), property.TypeInfo.Type.IsReferenceTypeAndNotString());
-            if (mockAssertionStatements.Count > 0)
-            {
-                bodyStatement = bodyStatement.WithTrailingTrivia(SyntaxFactory.Comment(Environment.NewLine + Environment.NewLine));
-            }
 
-            method = method.AddBodyStatements(bodyStatement);
+            method.Assert(bodyStatement);
+            method.BlankLine();
 
-            method = MockHelper.EmitStatementListWithTrivia(method, mockAssertionStatements, null, Environment.NewLine + Environment.NewLine);
+            method.Assert(mockAssertionStatements);
 
-            yield return method;
+            yield return method.Method;
         }
     }
 }

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/SingleConstructorInitializedPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/SingleConstructorInitializedPropertyGenerationStrategy.cs
@@ -65,10 +65,10 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.IsInitializedCorrectly, namingContext, false, model.IsStatic)
-                .AddBodyStatements(GetPropertyAssertionBodyStatements(property, model).ToArray());
+            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.IsInitializedCorrectly, namingContext, false, model.IsStatic);
+            method.Emit(GetPropertyAssertionBodyStatements(property, model).ToArray());
 
-            yield return method;
+            yield return method.Method;
         }
 
         private IEnumerable<StatementSyntax> GetPropertyAssertionBodyStatements(IPropertyModel property, ClassModel model)

--- a/src/Unitverse.Core/Strategies/PropertyGeneration/WriteOnlyPropertyGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/PropertyGeneration/WriteOnlyPropertyGenerationStrategy.cs
@@ -53,10 +53,10 @@
                 throw new ArgumentNullException(nameof(model));
             }
 
-            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanSet, namingContext, false, model.IsStatic)
-                .AddBodyStatements(GetPropertyAssertionBodyStatements(property, model).ToArray());
+            var method = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanSet, namingContext, false, model.IsStatic);
+            method.Emit(GetPropertyAssertionBodyStatements(property, model).ToArray());
 
-            yield return method;
+            yield return method.Method;
         }
 
         private IEnumerable<StatementSyntax> GetPropertyAssertionBodyStatements(IPropertyModel property, ClassModel sourceModel)

--- a/src/Unitverse.ExampleGenerator/DefaultGenerationOptions.cs
+++ b/src/Unitverse.ExampleGenerator/DefaultGenerationOptions.cs
@@ -29,5 +29,11 @@
         public bool AutomaticallyConfigureMocks => true;
 
         public bool EmitSubclassForProtectedMethods => true;
+
+        public string ArrangeComment => "Arrange";
+
+        public string ActComment => "Act";
+
+        public string AssertComment => "Assert";
     }
 }

--- a/src/Unitverse.ExampleGenerator/Examples.Designer.cs
+++ b/src/Unitverse.ExampleGenerator/Examples.Designer.cs
@@ -584,6 +584,32 @@ namespace Unitverse.ExampleGenerator {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to // ! Property Initialization Checks
+        ///// $ Demonstrates how properties that have matching constructor parameters are checked that they are initialized automatically
+        ///
+        ///namespace Unitverse.Examples
+        ///{
+        ///	using System;
+        ///
+        ///    public class ExampleClass
+        ///    {
+        ///        public ExampleClass(int identity, string description, Guid uniqueCode)
+        ///        {
+        ///            Identity = identity;
+        ///            Description = description;
+        ///            UniqueCode = uniqueCode;
+        ///        }
+        ///
+        ///        public int Identity { get; }
+        ///   [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string PropertyInitializationChecks {
+            get {
+                return ResourceManager.GetString("PropertyInitializationChecks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to // ! Record Types (init Properties)
         ///// $ Demonstrates the tests generated for a record type that has properties that have init accessors
         ///

--- a/src/Unitverse.ExampleGenerator/Examples.resx
+++ b/src/Unitverse.ExampleGenerator/Examples.resx
@@ -175,6 +175,9 @@
   <data name="PocoInitialization" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\PocoInitialization.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="PropertyInitializationChecks" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\PropertyInitializationChecks.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="RecordTypeInitProperties" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\RecordTypeInitProperties.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/Unitverse.ExampleGenerator/Resources/PropertyInitializationChecks.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/PropertyInitializationChecks.txt
@@ -1,0 +1,21 @@
+// ! Property Initialization Checks
+// $ Demonstrates how properties that have matching constructor parameters are checked that they are initialized automatically
+
+namespace Unitverse.Examples
+{
+	using System;
+
+    public class ExampleClass
+    {
+        public ExampleClass(int identity, string description, Guid uniqueCode)
+        {
+            Identity = identity;
+            Description = description;
+            UniqueCode = uniqueCode;
+        }
+
+        public int Identity { get; }
+        public string Description { get; }
+        public Guid UniqueCode { get; }
+    }
+}

--- a/src/Unitverse.Specs/GenerationOptions.cs
+++ b/src/Unitverse.Specs/GenerationOptions.cs
@@ -38,5 +38,11 @@
         public bool AutomaticallyConfigureMocks { get; } = true;
 
         public bool EmitSubclassForProtectedMethods { get; } = true;
+
+        public string ArrangeComment => "Arrange";
+
+        public string ActComment => "Act";
+
+        public string AssertComment => "Assert";
     }
 }

--- a/src/Unitverse/Options/GenerationOptions.cs
+++ b/src/Unitverse/Options/GenerationOptions.cs
@@ -71,5 +71,20 @@
         [DisplayName("Emit subclass for protected members")]
         [Description("Whether to emit a subclass that exposes protected methods to allow them to be tested")]
         public bool EmitSubclassForProtectedMethods { get; set; } = true;
+
+        [Category("Comments")]
+        [DisplayName("Arrange block comment")]
+        [Description("The comment to leave before any arrange statements (leave blank to suppress)")]
+        public string ArrangeComment { get; set; } = "Arrange";
+
+        [Category("Comments")]
+        [DisplayName("Act block comment")]
+        [Description("The comment to leave before any act statements (leave blank to suppress)")]
+        public string ActComment { get; set; } = "Act";
+
+        [Category("Comments")]
+        [DisplayName("Arrange block comment")]
+        [Description("The comment to leave before any assert statements (leave blank to suppress)")]
+        public string AssertComment { get; set; } = "Assert";
     }
 }

--- a/src/Unitverse/Options/StrategyOptions.cs
+++ b/src/Unitverse/Options/StrategyOptions.cs
@@ -59,12 +59,12 @@ namespace Unitverse.Options
 
         [Category("Operators")]
         [DisplayName("Basic Checks")]
-        [Description("Whether to emit tests to exercise properties (CanGet/Set*)")]
+        [Description("Whether to emit tests to exercise operators (CanCallOperator*)")]
         public bool OperatorChecksAreEnabled { get; set; } = true;
 
         [Category("Operators")]
         [DisplayName("Parameter Checks")]
-        [Description("Whether to emit null and string parameter checks for initializers (CannotCallOperatorWith*)")]
+        [Description("Whether to emit null and string parameter checks for operators (CannotCallOperatorWith*)")]
         public bool OperatorParameterChecksAreEnabled { get; set; } = true;
 
         [Category("Interfaces")]


### PR DESCRIPTION
Adds // Arrange, // Act and // Assert to unit tests as appropriate. Addresses #45.

Also, some tidy up - adds a property example to the docs, addressing #48 and also fixes some typos in the options dialogue for the selective strategies feature. Also adds documentation for that feature.