### PR TITLE
Fixing emission of subclass when not needed, updating the docs a bit

### DIFF
--- a/MarketplaceOverview.md
+++ b/MarketplaceOverview.md
@@ -1,12 +1,10 @@
 
-# Overview
-
-## Introduction
+## Introduction 👀
 The Unitverse extension generates tests for classes written in C#. The extension covers basic tests automatically (for example, checking for correct property initialization), and creates placeholder tests for methods. Unitverse aims to produce tests that compile, so that you can generate tests as you code, but still focus on what you are doing rather than divert your attention to fixing broken generated code. Unitverse also allows incremental test generation - as you add new members to your types you can add tests for those new members quickly through the editor. Also, if you refactor methods or constructor signatures, you can regenerate those tests quickly and easily.
 
 For more in-depth documentation, visit the [documentation on the readthedocs.io](https://unitverse.readthedocs.io/).
 
-## Using the Extension
+## Using the Extension 🔧
 
 Using the code editor context menu:
 
@@ -16,10 +14,10 @@ Using the solution explorer context menu:
 
 ![Solution Explorer context menu](https://raw.githubusercontent.com/mattwhitfield/unittestgenerator/master/docs/assets/SolutionContextMenu.png)
 
-## Visual Studio Versions
+## Visual Studio Versions 🆚
 Due to the transition to 64-bit, Visual Studio 2022 introduces some architectural differences that necessitate a separate VSIX package. If you're working with Visual Studio 2019, you will need [Unitverse for Visual Studio 2019](https://marketplace.visualstudio.com/items?itemName=MattWhitfield.Unitverse) and if you're working with Visual Studio 2022, you will need [Unitverse for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=MattWhitfield.UnitverseVS2022).
 
-## Supported Frameworks
+## Supported Frameworks 🖼
 #### Test Frameworks
 
 * MSTest 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 [![Visual Studio Marketplace Last Updated](https://img.shields.io/visual-studio-marketplace/last-updated/MattWhitfield.Unitverse?label=VS2019%20Last%20Updated)](https://marketplace.visualstudio.com/items?itemName=MattWhitfield.Unitverse)
 
 
-# Introduction
+# Introduction 👀
 
 Unitverse is an extension for [Visual Studio 2019](https://marketplace.visualstudio.com/items?itemName=MattWhitfield.Unitverse) and [Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=MattWhitfield.UnitverseVS2022) that generates tests for classes written in C#. There is a bunch of information about the extension in the documentation.
 
-# Documentation
+# Documentation 📖
 
 The best way to view the documentation is to visit visit the [documentation on the readthedocs.io](https://unitverse.readthedocs.io/). Alternatively, you can view the documentation right here on GitHub using the links to sections below.
 
@@ -18,10 +18,10 @@ The best way to view the documentation is to visit visit the [documentation on t
 * [Configuration](docs/configuration.md) - covering the configuration options available, as well as details on how to configure the extension through source code.
 * [Examples](docs/examples/index.md) - presents a selection of sample scenarios showing the source code and the generated tests.
 
-# Contributing
+# Contributing ✋
 
-Any contributions are welcome. Code. Feedback on what you like or what could be better. Please feel free to fork the repo and make changes, the license if MIT so you're pretty much free to do whatever you like.
+Any contributions are welcome. Code. Feedback on what you like or what could be better. Please feel free to fork the repo and make changes, the license if MIT so you're pretty much free to do whatever you like. For more information, please see the [contributing section](docs/contributing.md).
 
-## History
+## History 📅
 
 Unitverse was originally the SentryOne Unit Test Generator, and was written as part of an 'innovation sprint' where we wanted to write something that made our work more efficient. Unitverse is a fork of that project, and is not affiliated with any particular company. The license has also changed from Apache to MIT - please see the [license update notice](LicenseUpdateNotice.md) for details of this change. Thanks to all the original members of the team, as well as people who have submitted code/issues since then.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Unitverse isn't affiliated with any company, so the development is completely open source. As such, the development isn't guaranteed to be on any particular schedule. Any input from the community is hugely valuable, even if it's just raising an issue or suggesting a feature.
+
+If you want to go further, and contribute some code to the project, then this guide aims to give an indication of how the Unitverse extension is engineered and explain some of the decisions.
+
+## Solution Layout
+
+The code base on Unitverse is split into a few projects:
+
+| Project | Description |
+| - | - |
+| Unitverse | This project contains the Visual Studio specific functionality, adding commands to menus, providing options etc. It is intended to be as thin a wrapper as possible around the core code |
+| Unitverse.Core | This project is where the main magic happens. All the generation functionality, model extraction etc. exists within this project |
+| Unitverse.Core.Tests | This project contains unit tests for Unitverse.Core - the main aim is to ensure that Unitverse always produces code that compiles, hence a lot of tests aren't super specific about the output produced |
+| Unitverse.Specs | This project contains SpecFlow tests that ensure that the core generation functions of Unitverse operate correctly and produce the expected basic output |
+| Unitverse.ExampleGenerator | This project contains a small application that, for a set of example classes, produces the markdown output that forms the examples section in the documentation. This also forms the basis of the build protection - see the 'Build Protection' section below |
+
+## Unitverse.Core
+
+This project bears some more explanation as to it's layout - the main folders are:
+
+| Folder | Description |
+| - | - |
+| Assets | Things that can get added to test projects, like the NotifyPropertyChanged helper |
+| Frameworks\Assertion | Code that supports emitting tests using assertion frameworks |
+| Frameworks\Mocking | Code that supports using different mocking libraries |
+| Frameworks\Test | Code that supports using different test frameworks |
+| Helpers | General helper functions |
+| Models | Models to represent the input types for the generation process |
+| Options | Code to handle options classes, including loading from `.unitTestGeneratorConfig` files |
+| Resources | Test classes, used to validate that the code produced compiles using every different combination of available frameworks |
+| Strategies\ClassDecoration | Code that supports adding attributes to emitted test classes when necessary |
+| Strategies\ClassGeneration | Code that generates the basic test classes for different scenarios (standard/static/abstract) |
+| Strategies\ClassLevelGeneration | Code that generates tests that are grouped at the class level (i.e. constructors and initializers) |
+| Strategies\IndexerGeneration | Code that generates tests for indexers |
+| Strategies\IntefaceGeneration | Code that generates tests for specific interface implementations |
+| Strategies\MethodGeneration | Code that generates tests for methods |
+| Strategies\OperatorGeneration | Code that generates tests for operators |
+| Strategies\ProptertyGeneration | Code that generates tests for properties |
+| Strategies\ValueGeneration | Code that generates default values when they are needed (e.g. for method parameters) |
+
+The main bulk of the interesting code is in the `Strategies` folder. The `CoreGenerator` class is the main class from which generation happens.
+
+## Testing Ethos
+
+The general aim with the extension has not to be really specific about the output that is generated. So, for example, if a new method of deriving a default value for a type is added, it doesn't matter so much that it is done in an exact way. The most important thing is that the code compiles - Unitverse aims to 'get out of the way' of the developer so they can immediately think about how they want to go about testing the code they just wrote, instead of having to fix a bunch of broken code. Obviously, it won't generate tests that pass except for the simplest of cases, which is fine.
+
+There are some tests that check output - in the `Unitverse.Specs` project - and they check things like 'has a mock been generated for this dependency' and 'is this basic assert emitted'. But they are not designed to break every time something minor changes.
+
+Does that make sense?
+
+## Build Protection
+
+The example generator generates test classes for a bunch of known samples, and then emits markdown that form the 'examples' section in the documentation. It runs every build (when the example generator has built, it is called by the msbuild script in the post build actions). So then, if you have changed the output, you see the changes in the example documentation.
+
+When the build runs in GitHub Actions, it checks that the examples generated are the same as what has been checked in. It does this by checking that there are no uncommitted changes in the docs folder, and breaks the build if there are. So if you do make changes the generated tests, you have to 'accept' that by committing the newly generated markdown docs. Equally, when reviewing a PR, we can pay careful attention to the examples folder.
+
+## Areas for tidy up
+
+There are several things that could be better:
+
+* Although the existing tests do a really good job of making sure that we produce compilable code, we could always do with more tests
+* We could transition the code base to make use of nullable reference types
+* The `Generate` class isn't universally used - there are some strategies that make heavy use of SyntaxFactory directly
+* We could do with some better test output for specific scenarios - MVC controllers come to mind

--- a/docs/examples/AutomaticMockGeneration.md
+++ b/docs/examples/AutomaticMockGeneration.md
@@ -114,8 +114,8 @@ public class AutomaticMockGenerationExampleTests
     public async Task CanCallSampleAsyncMethod()
     {
         // Arrange
-        _dummyService.AsyncMethod().Returns("TestValue687431273");
-        _dummyService2.AsyncMethod(Arg.Any<string>()).Returns("TestValue2125508764");
+        _dummyService.AsyncMethod().Returns("TestValue534011718");
+        _dummyService2.AsyncMethod(Arg.Any<string>()).Returns("TestValue237820880");
 
         // Act
         await _testClass.SampleAsyncMethod();
@@ -131,11 +131,11 @@ public class AutomaticMockGenerationExampleTests
     public void CanCallSampleNoReturn()
     {
         // Arrange
-        var srr = "TestValue1321446349";
+        var srr = "TestValue929393559";
 
-        _dummyService.GenericMethod<string>(Arg.Any<string>()).Returns("TestValue1464848243");
-        _dummyService2.ReturnMethod(Arg.Any<string>(), Arg.Any<string>()).Returns(1406361028);
-        _dummyService2.SomeProp.Returns("TestValue607156385");
+        _dummyService.GenericMethod<string>(Arg.Any<string>()).Returns("TestValue1002897798");
+        _dummyService2.ReturnMethod(Arg.Any<string>(), Arg.Any<string>()).Returns(1657007234);
+        _dummyService2.SomeProp.Returns("TestValue1412011072");
 
         // Act
         _testClass.SampleNoReturn(srr);

--- a/docs/examples/ConstrainedGenericType.md
+++ b/docs/examples/ConstrainedGenericType.md
@@ -51,8 +51,8 @@ public class TestClass_2Tests
 
     public TestClass_2Tests()
     {
-        _insta = new Test { ThisIsAProperty = 1657007234 };
-        _insta2 = new TestBoth { ThisIsAProperty = 1412011072, ThisIsAnotherProperty = 929393559 };
+        _insta = new Test { ThisIsAProperty = 534011718 };
+        _insta2 = new TestBoth { ThisIsAProperty = 237820880, ThisIsAnotherProperty = 1002897798 };
         _testClass = new TestClass<T, R>(_insta, _insta2);
     }
 
@@ -69,13 +69,13 @@ public class TestClass_2Tests
     [Fact]
     public void CannotConstructWithNullInsta()
     {
-        FluentActions.Invoking(() => new TestClass<T, R>(default(T), new TestBoth { ThisIsAProperty = 760389092, ThisIsAnotherProperty = 2026928803 })).Should().Throw<ArgumentNullException>();
+        FluentActions.Invoking(() => new TestClass<T, R>(default(T), new TestBoth { ThisIsAProperty = 1657007234, ThisIsAnotherProperty = 1412011072 })).Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
     public void CannotConstructWithNullInsta2()
     {
-        FluentActions.Invoking(() => new TestClass<T, R>(new Test { ThisIsAProperty = 217468053 }, default(R))).Should().Throw<ArgumentNullException>();
+        FluentActions.Invoking(() => new TestClass<T, R>(new Test { ThisIsAProperty = 929393559 }, default(R))).Should().Throw<ArgumentNullException>();
     }
 
     [Fact]

--- a/docs/examples/DelegateGeneration.md
+++ b/docs/examples/DelegateGeneration.md
@@ -70,7 +70,7 @@ public static class TestClassTests
     public static void CanCallThisIsAMethod()
     {
         // Arrange
-        Func<string> func = () => "TestValue237820880";
+        Func<string> func = () => "TestValue534011718";
 
         // Act
         TestClass.ThisIsAMethod(func);
@@ -89,7 +89,7 @@ public static class TestClassTests
     public static void CanCallThisIsAMethod2()
     {
         // Arrange
-        Func<string, SomeClass> func = x => new SomeClass(1002897798);
+        Func<string, SomeClass> func = x => new SomeClass(237820880);
 
         // Act
         TestClass.ThisIsAMethod2(func);
@@ -108,7 +108,7 @@ public static class TestClassTests
     public static void CanCallThisIsAMethod3()
     {
         // Arrange
-        Func<int, string, SomeClass> func = (x, y) => new SomeClass(1657007234);
+        Func<int, string, SomeClass> func = (x, y) => new SomeClass(1002897798);
 
         // Act
         TestClass.ThisIsAMethod3(func);
@@ -127,7 +127,7 @@ public static class TestClassTests
     public static void CanCallThisIsAMethod4()
     {
         // Arrange
-        Func<int, int, string, SomeClass> func = (x, y, z) => new SomeClass(1412011072);
+        Func<int, int, string, SomeClass> func = (x, y, z) => new SomeClass(1657007234);
 
         // Act
         TestClass.ThisIsAMethod4(func);
@@ -146,7 +146,7 @@ public static class TestClassTests
     public static void CanCallThisIsAMethod5()
     {
         // Arrange
-        Func<int, int, int, string, SomeClass> func = (a, b, c, d) => new SomeClass(929393559);
+        Func<int, int, int, string, SomeClass> func = (a, b, c, d) => new SomeClass(1412011072);
 
         // Act
         TestClass.ThisIsAMethod5(func);

--- a/docs/examples/MappingMethod.md
+++ b/docs/examples/MappingMethod.md
@@ -42,7 +42,7 @@ public class MappingClassTests
     public void CanCallMap()
     {
         // Arrange
-        var inputClass = new InputClass { SomeOtherProperty = "TestValue929393559", InputOnlyProperty = "TestValue760389092" };
+        var inputClass = new InputClass { SomeOtherProperty = "TestValue534011718", InputOnlyProperty = "TestValue237820880" };
 
         // Act
         var result = _testClass.Map(inputClass);
@@ -61,7 +61,7 @@ public class MappingClassTests
     public void MapPerformsMapping()
     {
         // Arrange
-        var inputClass = new InputClass { SomeOtherProperty = "TestValue2026928803", InputOnlyProperty = "TestValue217468053" };
+        var inputClass = new InputClass { SomeOtherProperty = "TestValue1002897798", InputOnlyProperty = "TestValue1657007234" };
 
         // Act
         var result = _testClass.Map(inputClass);

--- a/docs/examples/PocoInitialization.md
+++ b/docs/examples/PocoInitialization.md
@@ -33,7 +33,7 @@ public class ConsumingClassTests
 
     public ConsumingClassTests()
     {
-        _poco = new SomePoco { Identity = 1512368656, Description = "TestValue1507096884", UniqueCode = new Guid("a34e5b13-846f-4aa5-df7a-0ea09ce3c117") };
+        _poco = new SomePoco { Identity = 534011718, Description = "TestValue237820880", UniqueCode = new Guid("97408286-a3e4-cf95-ff46-699c73c4a1cd") };
         _testClass = new ConsumingClass(_poco);
     }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,21 @@
 ![Latest release](https://img.shields.io/github/v/release/mattwhitfield/unittestgenerator?color=00A000) ![Last commit](https://img.shields.io/github/last-commit/mattwhitfield/unittestgenerator?color=00A000) ![Build status](https://img.shields.io/github/workflow/status/mattwhitfield/unittestgenerator/Extension%20build) ![Open issue count](https://img.shields.io/github/issues/mattwhitfield/unittestgenerator)
 
-# Introduction
+# Introduction 👀
 The Unitverse Visual Studio extension generates tests for classes written in C#. The extension covers basic tests automatically (for example, checking for correct property initialization), and creates placeholder tests for methods. Unitverse aims to produce tests that compile, so that you can generate tests as you code, but still focus on what you are doing rather than divert your attention to fixing broken generated code. Unitverse also allows incremental test generation - as you add new members to your types you can add tests for those new members quickly through the editor. Also, if you refactor methods or constructor signatures, you can regenerate those tests quickly and easily.
 
-### Documentation Sections
+### Documentation Sections 📖
 
 * [Getting started](gettingstarted.md) - covering basic usage and how to start generating tests.
 * [Features](features.md) - covers the features offered by Unitverse along with in-depth descriptions.
 * [Configuration](configuration.md) - covering the configuration options available, as well as details on how to configure the extension through source code.
 * [Examples](examples/index.md) - presents a selection of sample scenarios showing the source code and the generated tests.
 
-## Supported Environments
+## Supported Environments 🌳
 
-### Visual Studio Versions
+### Visual Studio Versions 🆚
 Due to the transition to 64-bit, Visual Studio 2022 introduces some architectural differences that necessitate a separate VSIX package. If you're working with Visual Studio 2019, you will need [Unitverse for Visual Studio 2019](https://marketplace.visualstudio.com/items?itemName=MattWhitfield.Unitverse) and if you're working with Visual Studio 2022, you will need [Unitverse for Visual Studio 2022](https://marketplace.visualstudio.com/items?itemName=MattWhitfield.UnitverseVS2022).
 
-### Supported Frameworks
+### Supported Frameworks 🖼
 #### Test Frameworks
 
 * MSTest 
@@ -24,12 +24,16 @@ Due to the transition to 64-bit, Visual Studio 2022 introduces some architectura
 
 FluentAssertions can also be used for assertions, replacing the assertions built in to whichever test framework is being used.
 
-#### Mocking Frameworks
+#### Mocking Frameworks 
 
 * NSubstitute 
 * Moq 
 * FakeItEasy 
 
-### Framework Auto-Detection
+### Framework Auto-Detection 🔍
 
 If Unitverse finds a test project related to the source project, it will look at the project references to determine what test and mocking frameworks to use. It will automatically use FluentAssertions if present. You can turn off framework auto-detection by going to Tools->Options->Unitverse.
+
+# Contributing ✋
+
+Any contributions are welcome. Code. Feedback on what you like or what could be better. Please feel free to fork the repo and make changes, the license if MIT so you're pretty much free to do whatever you like. For more information, please see the [contributing section](contributing.md).

--- a/src/Unitverse.Core/Models/ITestableModel.cs
+++ b/src/Unitverse.Core/Models/ITestableModel.cs
@@ -2,19 +2,24 @@
 {
     using Microsoft.CodeAnalysis;
 
-    public interface ITestableModel<out T>
-        where T : SyntaxNode
+    public interface ITestableModel
     {
         string Name { get; }
 
         string OriginalName { get; }
 
-        T Node { get; }
-
         void MutateName(string newName);
 
         bool ShouldGenerate { get; set; }
 
+        bool MarkedForGeneration { get; set; }
+
         void SetShouldGenerateForSingleItem(SyntaxNode syntaxNode);
+    }
+
+    public interface ITestableModel<out T> : ITestableModel
+        where T : SyntaxNode
+    {
+        T Node { get; }
     }
 }

--- a/src/Unitverse.Core/Models/TestableModel.cs
+++ b/src/Unitverse.Core/Models/TestableModel.cs
@@ -26,6 +26,8 @@
 
         public bool ShouldGenerate { get; set; } = true;
 
+        public bool MarkedForGeneration { get; set; }
+
         public void MutateName(string newName)
         {
             if (string.IsNullOrWhiteSpace(newName))

--- a/src/Unitverse.Core/Strategies/ClassGeneration/AbstractClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/AbstractClassGenerationStrategy.cs
@@ -37,7 +37,7 @@
 
             if (_frameworkSet.Options.GenerationOptions.EmitSubclassForProtectedMethods)
             {
-                return model.Methods.Any(x => x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword))) || model.Properties.Any(x => x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)));
+                return model.Methods.Any(x => x.MarkedForGeneration && x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword))) || model.Properties.Any(x => x.MarkedForGeneration && x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)));
             }
 
             return false;

--- a/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
@@ -35,7 +35,7 @@
 
             if (_frameworkSet.Options.GenerationOptions.EmitSubclassForProtectedMethods)
             {
-                return model.Methods.All(x => !x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword))) && model.Properties.All(x => !x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)));
+                return model.Methods.All(x => !(x.MarkedForGeneration && x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)))) && model.Properties.All(x => !(x.MarkedForGeneration && x.Node.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword))));
             }
 
             return true;

--- a/src/Unitverse.Core/Strategies/ValueGeneration/ValueGenerationStrategyFactory.cs
+++ b/src/Unitverse.Core/Strategies/ValueGeneration/ValueGenerationStrategyFactory.cs
@@ -15,10 +15,21 @@
 
         internal static bool PredictableGeneration { get; private set; }
 
+        private static int _seed = 0;
+
         public static void UsePredictableGeneration(int seed)
         {
             PredictableGeneration = true;
             Random = new Random(seed);
+            _seed = seed;
+        }
+
+        public static void ResetSeed()
+        {
+            if (_seed != 0)
+            {
+                UsePredictableGeneration(_seed);
+            }
         }
 
         private static IEnumerable<IValueGenerationStrategy> Strategies =>


### PR DESCRIPTION
This runs a pre-generation pass to mark members as emitted. This allows us to only generate a subclass for testing when it's actually needed. Addresses #46. Also some documentation updates, addressing #40 and adding emojis because that's apparently cool these days.