### PR TITLE
Support for Moq.AutoMock

### DIFF
--- a/MarketplaceOverview.md
+++ b/MarketplaceOverview.md
@@ -30,6 +30,7 @@ FluentAssertions can also be used for assertions, replacing the assertions built
 
 * NSubstitute 
 * Moq 
+* Moq with Moq.AutoMock
 * FakeItEasy 
 
 ### Framework Auto-Detection

--- a/docs/examples/FrameworksMsTestMoqAutoMock.md
+++ b/docs/examples/FrameworksMsTestMoqAutoMock.md
@@ -1,0 +1,110 @@
+﻿# Frameworks - MSTest & Moq (with Moq.AutoMock)
+Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework, using Moq.AutoMock for object creation
+
+### Source Type(s)
+``` csharp
+public interface IDependency
+{
+    void Method();
+}
+
+public class TestClass
+{
+    public TestClass(IDependency dependency)
+    { }
+
+    public void SomeMethod(string methodName, int methodValue)
+    {
+        System.Console.WriteLine("Testing this");
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    public System.Threading.Tasks.Task<int> SomeAsyncMethod(string methodName, int methodValue)
+    {
+        System.Console.WriteLine("Testing this");
+        return System.Threading.Tasks.Task.FromResult(0);
+    }
+}
+
+```
+
+### Generated Tests
+``` csharp
+[TestClass]
+public class TestClassTests
+{
+    private TestClass _testClass;
+    private Mock<IDependency> _dependency;
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        var mocker = new AutoMocker();
+        _dependency = mocker.GetMock<IDependency>();
+        _testClass = mocker.CreateInstance<TestClass>();
+    }
+
+    [TestMethod]
+    public void CanConstruct()
+    {
+        // Act
+        var instance = new TestClass(_dependency.Object);
+
+        // Assert
+        Assert.IsNotNull(instance);
+    }
+
+    [TestMethod]
+    public void CannotConstructWithNullDependency()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => new TestClass(default(IDependency)));
+    }
+
+    [TestMethod]
+    public void CanCallSomeMethod()
+    {
+        // Arrange
+        var methodName = "TestValue534011718";
+        var methodValue = 237820880;
+
+        // Act
+        _testClass.SomeMethod(methodName, methodValue);
+
+        // Assert
+        Assert.Fail("Create or modify test");
+    }
+
+    [DataTestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void CannotCallSomeMethodWithInvalidMethodName(string value)
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => _testClass.SomeMethod(value, 1002897798));
+    }
+
+    [TestMethod]
+    public async Task CanCallSomeAsyncMethod()
+    {
+        // Arrange
+        var methodName = "TestValue1657007234";
+        var methodValue = 1412011072;
+
+        // Act
+        var result = await _testClass.SomeAsyncMethod(methodName, methodValue);
+
+        // Assert
+        Assert.Fail("Create or modify test");
+    }
+
+    [DataTestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public async Task CannotCallSomeAsyncMethodWithInvalidMethodName(string value)
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => _testClass.SomeAsyncMethod(value, 929393559));
+    }
+}
+
+```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -11,6 +11,7 @@ This section contains examples of the output that Unitverse outputs, refreshed e
 | [Extension Methods](ExtensionMethod.md) | Demonstrates how Unitverse generates tests for extension methods |
 | [Frameworks - Fluent Assertions](FrameworksFluentAssertions.md) | Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework. Also shows using FluentAssertions for the assertion framework. |
 | [Frameworks - MSTest & Moq](FrameworksMsTestMoq.md) | Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework |
+| [Frameworks - MSTest & Moq (with Moq.AutoMock)](FrameworksMsTestMoqAutoMock.md) | Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework, using Moq.AutoMock for object creation |
 | [Frameworks - NUnit 3 & FakeItEasy](FrameworksNUnitFakeItEasy.md) | Demonstrates how tests are generated using NUnit 3 for the test framework and FakeItEasy for the mocking framework |
 | [Frameworks - XUnit & NSubstitute](FrameworksXUnitNSubstitute.md) | Demonstrates how tests are generated using XUnit for the test framework and NSubstitute for the mocking framework |
 | [Generic Methods](GenericMethod.md) | Demonstrates how Unitverse generates tests for generic methods |

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ FluentAssertions can also be used for assertions, replacing the assertions built
 
 * NSubstitute 
 * Moq 
+* Moq with Moq.AutoMock
 * FakeItEasy 
 
 ### Framework Auto-Detection 🔍

--- a/src/Unitverse.Core.Tests/Frameworks/FrameworkSetFactoryTests.cs
+++ b/src/Unitverse.Core.Tests/Frameworks/FrameworkSetFactoryTests.cs
@@ -29,6 +29,7 @@ namespace Unitverse.Core.Tests.Frameworks
         [Test]
         [TestCase(MockingFrameworkType.FakeItEasy, typeof(FakeItEasyMockingFramework))]
         [TestCase(MockingFrameworkType.Moq, typeof(MoqMockingFramework))]
+        [TestCase(MockingFrameworkType.MoqAutoMock, typeof(MoqAutoMockMockingFramework))]
         [TestCase(MockingFrameworkType.NSubstitute, typeof(NSubstituteMockingFramework))]
         public static void CanCallCreateForMockingFramework(MockingFrameworkType type, Type expectedType)
         {

--- a/src/Unitverse.Core.Tests/Helpers/FrameworkDetectionTests.cs
+++ b/src/Unitverse.Core.Tests/Helpers/FrameworkDetectionTests.cs
@@ -30,6 +30,7 @@ namespace Unitverse.Core.Tests.Helpers
         [TestCase("FakeItEasy", MockingFrameworkType.NSubstitute, MockingFrameworkType.FakeItEasy)]
         [TestCase("NSubstitute", MockingFrameworkType.Moq, MockingFrameworkType.NSubstitute)]
         [TestCase("Moq", MockingFrameworkType.NSubstitute, MockingFrameworkType.Moq)]
+        [TestCase("Moq.AutoMock", MockingFrameworkType.NSubstitute, MockingFrameworkType.MoqAutoMock)]
         [TestCase("fred", MockingFrameworkType.NSubstitute, MockingFrameworkType.NSubstitute)]
         [TestCase("fred", MockingFrameworkType.Moq, MockingFrameworkType.Moq)]
         public static void ResolveTargetFrameworksIdentifiesMockingFrameworks(string assemblyName, MockingFrameworkType baseType, MockingFrameworkType detectedType)

--- a/src/Unitverse.Core.Tests/Models/ClassModelTests.cs
+++ b/src/Unitverse.Core.Tests/Models/ClassModelTests.cs
@@ -87,14 +87,14 @@ namespace Unitverse.Core.Tests.Models
         public void CanCallGetObjectCreationExpression()
         {
             var frameworkSet = Substitute.For<IFrameworkSet>();
-            var result = _testClass.GetObjectCreationExpression(frameworkSet);
+            var result = _testClass.GetObjectCreationExpression(frameworkSet, false);
             Assert.That(result.NormalizeWhitespace().ToFullString().StartsWith("new ModelSource(\"TestValue", StringComparison.InvariantCultureIgnoreCase));
         }
 
         [Test]
         public void CannotCallGetObjectCreationExpressionWithNullFrameworkSet()
         {
-            Assert.Throws<ArgumentNullException>(() => _testClass.GetObjectCreationExpression(default(IFrameworkSet)));
+            Assert.Throws<ArgumentNullException>(() => _testClass.GetObjectCreationExpression(default(IFrameworkSet), false));
         }
 
         [Test]

--- a/src/Unitverse.Core.Tests/Unitverse.Core.Tests.csproj
+++ b/src/Unitverse.Core.Tests/Unitverse.Core.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq.AutoMock" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.13.2" />

--- a/src/Unitverse.Core/CoreGenerator.cs
+++ b/src/Unitverse.Core/CoreGenerator.cs
@@ -417,6 +417,8 @@
             {
                 frameworkSet.Context.TestClassesGenerated++;
 
+                frameworkSet.EvaluateTargetModel(c);
+
                 c.SetTargetInstance(frameworkSet.NamingProvider.TargetFieldName.Resolve(new NamingContext(c.ClassName)));
                 if (c.Declaration.Parent is NamespaceDeclarationSyntax namespaceDeclaration)
                 {

--- a/src/Unitverse.Core/Frameworks/FrameworkSet.cs
+++ b/src/Unitverse.Core/Frameworks/FrameworkSet.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using Unitverse.Core.Helpers;
+    using Unitverse.Core.Models;
     using Unitverse.Core.Options;
 
     public class FrameworkSet : IFrameworkSet
@@ -35,5 +36,12 @@
         public string TestTypeNaming { get; }
 
         public IUnitTestGeneratorOptions Options { get; }
+
+        public void EvaluateTargetModel(ClassModel classModel)
+        {
+            (TestFramework as IClassModelEvaluator)?.EvaluateTargetModel(classModel);
+            (AssertionFramework as IClassModelEvaluator)?.EvaluateTargetModel(classModel);
+            (MockingFramework as IClassModelEvaluator)?.EvaluateTargetModel(classModel);
+        }
     }
 }

--- a/src/Unitverse.Core/Frameworks/FrameworkSetFactory.cs
+++ b/src/Unitverse.Core/Frameworks/FrameworkSetFactory.cs
@@ -31,6 +31,8 @@
                     return new NSubstituteMockingFramework(context);
                 case MockingFrameworkType.Moq:
                     return new MoqMockingFramework(context);
+                case MockingFrameworkType.MoqAutoMock:
+                    return new MoqAutoMockMockingFramework(context);
                 case MockingFrameworkType.FakeItEasy:
                     return new FakeItEasyMockingFramework(context);
                 default:

--- a/src/Unitverse.Core/Frameworks/IClassModelEvaluator.cs
+++ b/src/Unitverse.Core/Frameworks/IClassModelEvaluator.cs
@@ -1,0 +1,9 @@
+﻿namespace Unitverse.Core.Frameworks
+{
+    using Unitverse.Core.Models;
+
+    public interface IClassModelEvaluator
+    {
+        void EvaluateTargetModel(ClassModel classModel);
+    }
+}

--- a/src/Unitverse.Core/Frameworks/IFrameworkSet.cs
+++ b/src/Unitverse.Core/Frameworks/IFrameworkSet.cs
@@ -3,7 +3,7 @@
     using Unitverse.Core.Helpers;
     using Unitverse.Core.Options;
 
-    public interface IFrameworkSet
+    public interface IFrameworkSet : IClassModelEvaluator
     {
         IUnitTestGeneratorOptions Options { get; }
 

--- a/src/Unitverse.Core/Frameworks/IMockingFramework.cs
+++ b/src/Unitverse.Core/Frameworks/IMockingFramework.cs
@@ -23,5 +23,9 @@
         ExpressionSyntax GetSetupFor(IPropertySymbol dependencyProperty, string mockFieldName, SemanticModel model, IFrameworkSet frameworkSet, ExpressionSyntax expectedReturnValue);
 
         ExpressionSyntax GetAssertionFor(IMethodSymbol dependencyMethod, string mockFieldName, SemanticModel model, IFrameworkSet frameworkSet, IEnumerable<string> parameters);
+
+        BaseMethodDeclarationSyntax AddSetupMethodStatements(BaseMethodDeclarationSyntax setupMethod);
+
+        ExpressionSyntax GetObjectCreationExpression(TypeSyntax typeSyntax);
     }
 }

--- a/src/Unitverse.Core/Frameworks/Mocking/FakeItEasyMockingFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Mocking/FakeItEasyMockingFramework.cs
@@ -111,6 +111,16 @@
             return SyntaxFactory.InvocationExpression(aCallTo).WithArgumentList(Generate.Arguments(SyntaxFactory.ParenthesizedLambdaExpression().WithExpressionBody(methodCall)));
         }
 
+        public BaseMethodDeclarationSyntax AddSetupMethodStatements(BaseMethodDeclarationSyntax setupMethod)
+        {
+            return setupMethod;
+        }
+
+        public ExpressionSyntax GetObjectCreationExpression(TypeSyntax type)
+        {
+            return null;
+        }
+
         public bool AwaitAsyncAssertions => false;
     }
 }

--- a/src/Unitverse.Core/Frameworks/Mocking/MoqAutoMockMockingFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Mocking/MoqAutoMockMockingFramework.cs
@@ -1,0 +1,94 @@
+﻿namespace Unitverse.Core.Frameworks.Mocking
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Unitverse.Core.Helpers;
+    using Unitverse.Core.Models;
+    using Unitverse.Core.Resources;
+
+    public class MoqAutoMockMockingFramework : MoqMockingFramework, IClassModelEvaluator
+    {
+        private readonly IGenerationContext _context;
+
+        public MoqAutoMockMockingFramework(IGenerationContext context)
+            : base(context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public bool IsActive { get; private set; }
+
+        public void EvaluateTargetModel(ClassModel classModel)
+        {
+            // activate if the class model primary constructor takes all interface params, or there is no primary constructor
+            IsActive =
+                classModel.DefaultConstructor == null ||
+                classModel.DefaultConstructor.Parameters.All(x => x.TypeInfo.Type.TypeKind == TypeKind.Interface);
+        }
+
+        public override IEnumerable<UsingDirectiveSyntax> GetUsings()
+        {
+            if (IsActive)
+            {
+                yield return SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("Moq.AutoMock"));
+            }
+
+            foreach (var usingStatement in base.GetUsings())
+            {
+                yield return usingStatement;
+            }
+        }
+
+        public override BaseMethodDeclarationSyntax AddSetupMethodStatements(BaseMethodDeclarationSyntax setupMethod)
+        {
+            if (IsActive)
+            {
+                _context.MocksUsed = true;
+                var creation = Generate.ImplicitlyTypedVariableDeclaration("mocker", Generate.ObjectCreation(SyntaxFactory.IdentifierName("AutoMocker")));
+                setupMethod = setupMethod.AddBodyStatements(creation);
+            }
+
+            return setupMethod;
+        }
+
+        public override ExpressionSyntax GetFieldInitializer(TypeSyntax type)
+        {
+            if (IsActive)
+            {
+                var typeList = SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList(type));
+
+                _context.MocksUsed = true;
+                return SyntaxFactory.InvocationExpression(
+                           SyntaxFactory.MemberAccessExpression(
+                               SyntaxKind.SimpleMemberAccessExpression,
+                               SyntaxFactory.IdentifierName("mocker"),
+                               SyntaxFactory.GenericName(SyntaxFactory.Identifier("GetMock"))
+                                            .WithTypeArgumentList(typeList)));
+            }
+
+            return base.GetFieldInitializer(type);
+        }
+
+        public override ExpressionSyntax GetObjectCreationExpression(TypeSyntax type)
+        {
+            if (IsActive)
+            {
+                var typeList = SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList(type));
+
+                _context.MocksUsed = true;
+                return SyntaxFactory.InvocationExpression(
+                           SyntaxFactory.MemberAccessExpression(
+                               SyntaxKind.SimpleMemberAccessExpression,
+                               SyntaxFactory.IdentifierName("mocker"),
+                               SyntaxFactory.GenericName(SyntaxFactory.Identifier("CreateInstance"))
+                                            .WithTypeArgumentList(typeList)));
+            }
+
+            return base.GetObjectCreationExpression(type);
+        }
+    }
+}

--- a/src/Unitverse.Core/Frameworks/Mocking/MoqMockingFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Mocking/MoqMockingFramework.cs
@@ -17,7 +17,7 @@
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-        public IEnumerable<UsingDirectiveSyntax> GetUsings()
+        public virtual IEnumerable<UsingDirectiveSyntax> GetUsings()
         {
             yield return SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("Moq"));
         }
@@ -57,17 +57,22 @@
             _context.MocksUsed = true;
             return SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    GetFieldInitializer(type),
+                    GetMoqFieldInitializer(type),
                     SyntaxFactory.IdentifierName("Object"));
         }
 
-        public ExpressionSyntax GetFieldInitializer(TypeSyntax type)
+        public virtual ExpressionSyntax GetFieldInitializer(TypeSyntax type)
         {
             if (type is null)
             {
                 throw new ArgumentNullException(nameof(type));
             }
 
+            return GetMoqFieldInitializer(type);
+        }
+
+        private ExpressionSyntax GetMoqFieldInitializer(TypeSyntax type)
+        {
             _context.MocksUsed = true;
             return SyntaxFactory.ObjectCreationExpression(SyntaxFactory.GenericName(SyntaxFactory.Identifier("Mock"))
                                                                        .WithTypeArgumentList(SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList(type))))
@@ -127,6 +132,16 @@
         {
             var mockSetup = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName(mockFieldName), SyntaxFactory.IdentifierName(actionName));
             return SyntaxFactory.InvocationExpression(mockSetup).WithArgumentList(Generate.Arguments(SyntaxFactory.SimpleLambdaExpression(Generate.Parameter("mock"), methodCall)));
+        }
+
+        public virtual BaseMethodDeclarationSyntax AddSetupMethodStatements(BaseMethodDeclarationSyntax setupMethod)
+        {
+            return setupMethod;
+        }
+
+        public virtual ExpressionSyntax GetObjectCreationExpression(TypeSyntax type)
+        {
+            return null;
         }
 
         public bool AwaitAsyncAssertions => false;

--- a/src/Unitverse.Core/Frameworks/Mocking/NSubstituteMockingFramework.cs
+++ b/src/Unitverse.Core/Frameworks/Mocking/NSubstituteMockingFramework.cs
@@ -107,6 +107,16 @@
             return MockingHelper.GetMethodCall(dependencyMethod, received, MockingHelper.TranslateArgumentFunc(GetArgument, parameters), frameworkSet.Context);
         }
 
+        public BaseMethodDeclarationSyntax AddSetupMethodStatements(BaseMethodDeclarationSyntax setupMethod)
+        {
+            return setupMethod;
+        }
+
+        public ExpressionSyntax GetObjectCreationExpression(TypeSyntax type)
+        {
+            return null;
+        }
+
         public bool AwaitAsyncAssertions => true;
     }
 }

--- a/src/Unitverse.Core/Helpers/FrameworkDetection.cs
+++ b/src/Unitverse.Core/Helpers/FrameworkDetection.cs
@@ -43,6 +43,7 @@
         {
             new Matcher<MockingFrameworkType>("FakeItEasy", null, MockingFrameworkType.FakeItEasy),
             new Matcher<MockingFrameworkType>("NSubstitute", null, MockingFrameworkType.NSubstitute),
+            new Matcher<MockingFrameworkType>("Moq.AutoMock", null, MockingFrameworkType.MoqAutoMock),
             new Matcher<MockingFrameworkType>("Moq", null, MockingFrameworkType.Moq),
         };
 

--- a/src/Unitverse.Core/Helpers/Generate.cs
+++ b/src/Unitverse.Core/Helpers/Generate.cs
@@ -346,6 +346,8 @@
 
             var setupMethod = frameworkSet.TestFramework.CreateSetupMethod(targetTypeName);
 
+            setupMethod = frameworkSet.MockingFramework.AddSetupMethodStatements(setupMethod);
+
             var parametersEmitted = new HashSet<ParameterModel>(new ParameterModelComparer());
 
             // generate fields for each constructor parameter

--- a/src/Unitverse.Core/Models/ClassModel.cs
+++ b/src/Unitverse.Core/Models/ClassModel.cs
@@ -190,14 +190,23 @@
             return identifierName;
         }
 
-        public ExpressionSyntax GetObjectCreationExpression(IFrameworkSet frameworkSet)
+        public ExpressionSyntax GetObjectCreationExpression(IFrameworkSet frameworkSet, bool forSetupMethod)
         {
             if (frameworkSet == null)
             {
                 throw new ArgumentNullException(nameof(frameworkSet));
             }
 
-            var targetConstructor = Constructors.OrderByDescending(x => x.Parameters.Count).FirstOrDefault();
+            var targetConstructor = DefaultConstructor ?? Constructors.OrderByDescending(x => x.Parameters.Count).FirstOrDefault();
+
+            if (forSetupMethod)
+            {
+                var mockedCreationExpression = frameworkSet.MockingFramework.GetObjectCreationExpression(TypeSyntax);
+                if (mockedCreationExpression != null)
+                {
+                    return mockedCreationExpression;
+                }
+            }
 
             var objectCreation = SyntaxFactory.ObjectCreationExpression(TypeSyntax);
 

--- a/src/Unitverse.Core/Options/MockingFrameworkType.cs
+++ b/src/Unitverse.Core/Options/MockingFrameworkType.cs
@@ -5,5 +5,6 @@
         NSubstitute,
         Moq,
         FakeItEasy,
+        MoqAutoMock,
     }
 }

--- a/src/Unitverse.Core/Strategies/ClassGeneration/AbstractClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/AbstractClassGenerationStrategy.cs
@@ -75,7 +75,7 @@
             var identifierNameSyntax = SyntaxFactory.IdentifierName("Test" + model.ClassName);
             model.TypeSyntax = identifierNameSyntax;
 
-            var creationExpression = model.GetObjectCreationExpression(_frameworkSet);
+            var creationExpression = model.GetObjectCreationExpression(_frameworkSet, true);
 
             var assignment = SyntaxFactory.AssignmentExpression(
                 SyntaxKind.SimpleAssignmentExpression,

--- a/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassGeneration/StandardClassGenerationStrategy.cs
@@ -68,7 +68,7 @@
 
             var setupMethod = Generate.SetupMethod(model, targetTypeName, _frameworkSet, ref classDeclaration);
 
-            var creationExpression = model.GetObjectCreationExpression(_frameworkSet);
+            var creationExpression = model.GetObjectCreationExpression(_frameworkSet, true);
 
             var assignment = SyntaxFactory.AssignmentExpression(
                 SyntaxKind.SimpleAssignmentExpression,

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructSingleConstructorGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanConstructSingleConstructorGenerationStrategy.cs
@@ -65,7 +65,7 @@
 
             var generatedMethod = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanConstruct, namingContext, false, false);
 
-            generatedMethod.Act(Generate.ImplicitlyTypedVariableDeclaration("instance", model.GetObjectCreationExpression(_frameworkSet)));
+            generatedMethod.Act(Generate.ImplicitlyTypedVariableDeclaration("instance", model.GetObjectCreationExpression(_frameworkSet, false)));
 
             generatedMethod.Assert(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
 

--- a/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanInitializeGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/ClassLevelGeneration/CanInitializeGenerationStrategy.cs
@@ -60,7 +60,7 @@
 
             var generatedMethod = _frameworkSet.TestFramework.CreateTestMethod(_frameworkSet.NamingProvider.CanInitialize, namingContext, false, false);
 
-            generatedMethod.Act(Generate.ImplicitlyTypedVariableDeclaration("instance", model.GetObjectCreationExpression(_frameworkSet)));
+            generatedMethod.Act(Generate.ImplicitlyTypedVariableDeclaration("instance", model.GetObjectCreationExpression(_frameworkSet, false)));
 
             generatedMethod.Assert(_frameworkSet.AssertionFramework.AssertNotNull(SyntaxFactory.IdentifierName("instance")));
 

--- a/src/Unitverse.Core/Strategies/InterfaceGeneration/EquatableGenerationStrategy.cs
+++ b/src/Unitverse.Core/Strategies/InterfaceGeneration/EquatableGenerationStrategy.cs
@@ -42,7 +42,7 @@
             ExpressionSyntax sameExpression;
             if (equatableTypeSymbol == sourceModel.TypeSymbol)
             {
-                sameExpression = sourceModel.GetObjectCreationExpression(FrameworkSet);
+                sameExpression = sourceModel.GetObjectCreationExpression(FrameworkSet, false);
             }
             else
             {

--- a/src/Unitverse.ExampleGenerator/Examples.Designer.cs
+++ b/src/Unitverse.ExampleGenerator/Examples.Designer.cs
@@ -184,13 +184,9 @@ namespace Unitverse.ExampleGenerator {
         ///        public int Val { get; }
         ///    }
         ///
-        ///    public static class TestClass
-        ///    {
-        ///        public static void ThisIsAMethod(Func&lt;string&gt; func)
-        ///        {
-        ///        }
+        ///	public delegate SomeClass HasOutParamAndReturnType(SomeClass input, out string output);
         ///
-        ///        public static voi [rest of string was truncated]&quot;;.
+        ///	public delegate void HasOutParam(string input, out string o [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DelegateGeneration {
             get {
@@ -278,6 +274,33 @@ namespace Unitverse.ExampleGenerator {
         internal static string FrameworksMsTestMoq {
             get {
                 return ResourceManager.GetString("FrameworksMsTestMoq", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to // ! Frameworks - MSTest &amp; Moq (with Moq.AutoMock)
+        ///// $ Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework, using Moq.AutoMock for object creation
+        ///// # FrameworkType=MSTest
+        ///// # MockingFrameworkType=MoqAutoMock
+        ///// # UseFluentAssertions=false
+        ///
+        ///namespace Unitverse.Examples
+        ///{
+        ///    public interface IDependency
+        ///    {
+        ///        void Method();
+        ///    }
+        ///
+        ///    public class TestClass
+        ///    {
+        ///        public TestClass(IDependency dependency)
+        ///        { }
+        ///
+        /// [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string FrameworksMsTestMoqAutoMock {
+            get {
+                return ResourceManager.GetString("FrameworksMsTestMoqAutoMock", resourceCulture);
             }
         }
         

--- a/src/Unitverse.ExampleGenerator/Examples.resx
+++ b/src/Unitverse.ExampleGenerator/Examples.resx
@@ -142,6 +142,9 @@
   <data name="FrameworksMsTestMoq" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\FrameworksMsTestMoq.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="FrameworksMsTestMoqAutoMock" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>Resources\FrameworksMsTestMoqAutoMock.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="FrameworksNUnitFakeItEasy" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\FrameworksNUnitFakeItEasy.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/Unitverse.ExampleGenerator/Program.cs
+++ b/src/Unitverse.ExampleGenerator/Program.cs
@@ -25,6 +25,7 @@ using FakeItEasy;
 using Xunit;
 using NUnit.Framework;
 using Unitverse.Core.Strategies.ValueGeneration;
+using Moq.AutoMock;
 
 namespace Unitverse.ExampleGenerator
 {
@@ -256,6 +257,11 @@ namespace Unitverse.ExampleGenerator
                     break;
 
                 case MockingFrameworkType.Moq:
+                    yield return MetadataReference.CreateFromFile(typeof(Mock).Assembly.Location);
+                    break;
+
+                case MockingFrameworkType.MoqAutoMock:
+                    yield return MetadataReference.CreateFromFile(typeof(AutoMocker).Assembly.Location);
                     yield return MetadataReference.CreateFromFile(typeof(Mock).Assembly.Location);
                     break;
 

--- a/src/Unitverse.ExampleGenerator/Resources/FrameworksMsTestMoqAutoMock.txt
+++ b/src/Unitverse.ExampleGenerator/Resources/FrameworksMsTestMoqAutoMock.txt
@@ -1,0 +1,31 @@
+// ! Frameworks - MSTest & Moq (with Moq.AutoMock)
+// $ Demonstrates how tests are generated using MsTest for the test framework and Moq for the mocking framework, using Moq.AutoMock for object creation
+// # FrameworkType=MSTest
+// # MockingFrameworkType=MoqAutoMock
+// # UseFluentAssertions=false
+
+namespace Unitverse.Examples
+{
+    public interface IDependency
+    {
+        void Method();
+    }
+
+    public class TestClass
+    {
+        public TestClass(IDependency dependency)
+        { }
+
+        public void SomeMethod(string methodName, int methodValue)
+        {
+            System.Console.WriteLine("Testing this");
+            return System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        public System.Threading.Tasks.Task<int> SomeAsyncMethod(string methodName, int methodValue)
+        {
+            System.Console.WriteLine("Testing this");
+            return System.Threading.Tasks.Task.FromResult(0);
+        }
+    }
+}

--- a/src/Unitverse.ExampleGenerator/Unitverse.ExampleGenerator.csproj
+++ b/src/Unitverse.ExampleGenerator/Unitverse.ExampleGenerator.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq.AutoMock" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="nunit" Version="3.13.2" />

--- a/src/Unitverse/Manifests/VS2019/source.extension.vsixmanifest
+++ b/src/Unitverse/Manifests/VS2019/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
     <Metadata>
         <Identity Id="Unitverse.558939c8-3b53-401f-8a4f-6d413ec81313" Version="1.0.35" Language="en-US" Publisher="mattwhitfield" />
         <DisplayName>Unitverse for Visual Studio 2019</DisplayName>
-        <Description xml:space="preserve">Unitverse generates better boiler plate unit test code for existing classes.</Description>
+        <Description xml:space="preserve">Unitverse is a unit test generator that generates better boiler plate unit test code for existing classes.</Description>
         <Icon>Resources\UnitTestGeneratorPackage.png</Icon>
         <PreviewImage>Resources\UnitTestGeneratorPackage.png</PreviewImage>
     </Metadata>

--- a/src/Unitverse/Manifests/VS2022/source.extension.vsixmanifest
+++ b/src/Unitverse/Manifests/VS2022/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
     <Metadata>
         <Identity Id="Unitverse.c983573f-62aa-4c3d-8192-5d3190f9ee22" Version="1.0.35" Language="en-US" Publisher="mattwhitfield" />
         <DisplayName>Unitverse for Visual Studio 2022</DisplayName>
-        <Description xml:space="preserve">Unitverse generates better boiler plate unit test code for existing classes.</Description>
+        <Description xml:space="preserve">Unitverse is a unit test generator that generates better boiler plate unit test code for existing classes.</Description>
         <Icon>Resources\UnitTestGeneratorPackage.png</Icon>
         <PreviewImage>Resources\UnitTestGeneratorPackage.png</PreviewImage>
     </Metadata>


### PR DESCRIPTION
Adds support for Moq.AutoMock for object creation when all parameters to the test class are interfaces
Resolves #44 